### PR TITLE
Make empty search box redirect to root page

### DIFF
--- a/app/controllers/crop_searches_controller.rb
+++ b/app/controllers/crop_searches_controller.rb
@@ -1,8 +1,12 @@
 class CropSearchesController < ApplicationController
 
   def search
-    @results = Crop.full_text_search(crop_search_params,{:max_results => 100})
-    render :show
+    if (crop_search_params[:q].empty?)
+      redirect_to root_path
+    else
+      @results = Crop.full_text_search(crop_search_params,{:max_results => 100})
+      render :show
+    end
   end
 
   private

--- a/spec/features/crop_searches_spec.rb
+++ b/spec/features/crop_searches_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-describe 'Crop searches' do
+describe 'CropSearchesController', :type => :controller do
   let!(:crop){FactoryGirl.create(:crop)}
 
   it 'finds documents' do
@@ -10,7 +10,12 @@ describe 'Crop searches' do
     expect(page).to have_content('Horseradish (Armoracia rusticana, syn. Cochlearia armoracia)')
   end
 
-  it 'handles empty searches'
+  it 'handles empty searches' do
+    visit root_path
+    fill_in 'q', with: ''
+    click_button 'Search!'
+    current_url.should == root_url
+  end
 
   it 'handles pagination'
 


### PR DESCRIPTION
I noticed that leaving the search box blank and clicking search returned everything in my local kong instance back to the user. I looked at Google and Bing, and neither of these engines behave this same way (Google doesn't allow the button to be pressed, and Bing redirects back to the same page.)

This PR redirects empty searches back to the root page and fills in a previous pending test for the behavior.
