### PR TITLE
Removed .hero input.search padding

### DIFF
--- a/app/assets/stylesheets/home.css.scss
+++ b/app/assets/stylesheets/home.css.scss
@@ -28,10 +28,6 @@
     height: 50px;
     font-size: 1.2em;
 
-    &.search {
-      padding: 1em;
-    }
-
     &.button {
       background-color: #85CB2B;
       border-color: #4BA122;


### PR DESCRIPTION
This fixes an issue where Firefox renders the search field all strangely. Fixes #49
