### PR TITLE
Fix Jquery deprecations

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
 source 'https://rubygems.org'
+source 'https://rails-assets.org'
 
 ruby '2.1.1'
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
@@ -6,26 +7,19 @@ gem 'rails', '4.0.2'
 
 gem 'rails_12factor' # for dokku
 
-# Foundation
-gem 'zurb-foundation', '4.3.2'
-
-# Use SCSS for stylesheets
-gem 'sass-rails', '~> 4.0.0'
-
-# Use Uglifier as compressor for JavaScript assets
-gem 'uglifier', '>= 1.3.0'
-
-# Use CoffeeScript for .js.coffee assets and views
-gem 'coffee-rails'
-
-# See https://github.com/sstephenson/execjs#readme for more supported runtimes
-gem 'therubyracer', platforms: :ruby
-
-# Use jquery as the JavaScript library
+# assets
+gem 'rails-assets-jquery'
+gem 'rails-assets-foundation'
 gem 'jquery-rails'
 
+gem 'sass-rails', '~> 4.0.0'
+gem 'uglifier', '>= 1.3.0'
+gem 'coffee-rails'
+gem 'therubyracer', platforms: :ruby
+
+
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
-gem 'jbuilder'
+# gem 'jbuilder'
 
 gem 'bcrypt-ruby'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,6 +10,7 @@ GIT
 
 GEM
   remote: https://rubygems.org/
+  remote: https://rails-assets.org/
   specs:
     actionmailer (4.0.2)
       actionpack (= 4.0.2)
@@ -82,9 +83,6 @@ GEM
     hike (1.2.3)
     httpauth (0.2.0)
     i18n (0.6.9)
-    jbuilder (1.5.3)
-      activesupport (>= 3.0.0)
-      multi_json (>= 1.2.0)
     jquery-rails (3.0.4)
       railties (>= 3.0, < 5.0)
       thor (>= 0.14, < 2.0)
@@ -159,6 +157,18 @@ GEM
       bundler (>= 1.3.0, < 2.0)
       railties (= 4.0.2)
       sprockets-rails (~> 2.0.0)
+    rails-assets-fastclick (1.0.2)
+    rails-assets-foundation (5.3.0)
+      rails-assets-fastclick (>= 0.6.11)
+      rails-assets-jquery (>= 2.1.0)
+      rails-assets-jquery-placeholder (~> 2.0.7)
+      rails-assets-jquery.cookie (~> 1.4.0)
+      rails-assets-modernizr (>= 2.7.2)
+    rails-assets-jquery (2.1.1)
+    rails-assets-jquery-placeholder (2.0.8)
+    rails-assets-jquery.cookie (1.4.1)
+      rails-assets-jquery (>= 1.2)
+    rails-assets-modernizr (2.8.2)
     rails_12factor (0.0.2)
       rails_serve_static_assets
       rails_stdout_logging
@@ -226,8 +236,6 @@ GEM
     websocket-driver (0.3.1)
     xpath (2.0.0)
       nokogiri (~> 1.3)
-    zurb-foundation (4.3.2)
-      sass (>= 3.2.0)
 
 PLATFORMS
   ruby
@@ -241,7 +249,6 @@ DEPENDENCIES
   devise
   factory_girl_rails
   high_voltage
-  jbuilder
   jquery-rails
   launchy
   mongoid!
@@ -252,6 +259,8 @@ DEPENDENCIES
   pry
   pry-nav
   rails (= 4.0.2)
+  rails-assets-foundation
+  rails-assets-jquery
   rails_12factor
   rspec-rails
   sass-rails (~> 4.0.0)
@@ -259,4 +268,3 @@ DEPENDENCIES
   simplecov
   therubyracer
   uglifier (>= 1.3.0)
-  zurb-foundation (= 4.3.2)

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -15,7 +15,9 @@
         <title>
             <%= content_for?(:title) ? yield(:title) : "OpenFarm" %>
         </title>
-        <link href='http://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,600,700,900' rel='stylesheet' type='text/css'><%= stylesheet_link_tag    "application" %><%= javascript_include_tag "vendor/custom.modernizr" %><%= csrf_meta_tags %>
+        <link href='http://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,600,700,900' rel='stylesheet' type='text/css'>
+        <%= stylesheet_link_tag "application" %>
+        <%= csrf_meta_tags %>
     </head>
     <body>
         <nav class="top-bar" data-topbar>


### PR DESCRIPTION
# Why?
- `use of getPreventDefault() is deprecated. Use defaultPrevented instead.` Fixes #62 .
# What Changed?
- Pulled down the latest Jquery via [Rails-Assets](https://rails-assets.org/).
- Pulled down zurb foundation via rails-assets also (for consistency)
