### PR TITLE
Remove Leftovers from Scaffolding

### DIFF
--- a/spec/controllers/requirement_controller_spec.rb
+++ b/spec/controllers/requirement_controller_spec.rb
@@ -1,5 +1,0 @@
-require 'spec_helper'
-
-describe RequirementController do
-
-end

--- a/spec/controllers/stage_controller_spec.rb
+++ b/spec/controllers/stage_controller_spec.rb
@@ -1,5 +1,0 @@
-require 'spec_helper'
-
-describe StageController do
-
-end


### PR DESCRIPTION
Our test suite was crashing because of some leftover controller specs (probably from running scaffolds). This is just a deletion of those files.
