### PR TITLE
Minor changes

### DIFF
--- a/app/controllers/crop_searches_controller.rb
+++ b/app/controllers/crop_searches_controller.rb
@@ -1,26 +1,11 @@
 class CropSearchesController < ApplicationController
 
   def search
-    #make sure the user entered some search text, if not flash an error
-    if !crop_search_params[:searchtext].present?
-      flash[:alert] = "Search can't be blank"
-      return redirect_to root_path
-    end
-    #perform the search
-    @results = Crop.full_text_search(crop_search_params[:searchtext],{:max_results => 100})
+    @results = Crop.full_text_search(params[:q],{:max_results => 100})
     #if the search came back with nothing, redirect to home and tell user
-    if !@results.present?
-      flash[:alert] = "No Crops found for: #{crop_search_params[:searchtext]}"
-      return redirect_to root_path
+    if @results.empty?
+      @results = Crop.all.limit(100)
     end
     render :show
   end
-
-  private
-
-    # Never trust parameters from the scary internet, only allow the white
-    # list through.
-    def crop_search_params
-      params.require(:cropsearch).permit(:searchtext)
-    end
 end

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -13,7 +13,7 @@
                 <div class="small-12 small-centered columns">
                     <div class="row collapse">
                         <div class="small-8 large-9 columns">
-                          <%= f.text_field :searchtext, maxlength:"120", class: 'search', placeholder: "What do you want to grow?" %>
+                          <%= f.text_field :q, id: :q, maxlength:"120", class: 'search', placeholder: "What do you want to grow?" %>
                         </div>
                         <div class="small-4 large-3 columns">
                           <%= f.submit "Search!", data: { disable_with: "Searching..." }, class: 'button postfix' %>

--- a/spec/features/crop_searches_spec.rb
+++ b/spec/features/crop_searches_spec.rb
@@ -5,20 +5,15 @@ describe 'Crop search', :type => :controller do
 
   it 'finds documents' do
     visit root_path
-    fill_in 'cropsearch_searchtext', with: 'radish'
+    fill_in 'q', with: 'radish'
     click_button 'Search!'
     expect(page).to have_content('Horseradish (Armoracia rusticana, syn. Cochlearia armoracia)')
   end
 
   it 'handles empty searches' do
     visit root_path
-    fill_in 'cropsearch_searchtext', with: ''
+    fill_in 'q', with: ''
     click_button 'Search!'
-    current_url.should == root_url
+    expect(page).to have_content('Horseradish (Armoracia rusticana, syn. Cochlearia armoracia)')
   end
-
-  it 'handles pagination'
-
-  it 'paginates results'
-
 end


### PR DESCRIPTION
- Changed `crop_search_params` back to `q` (broke some forms on production, was too hard to write out/share links)
- Spec updates
- Empty searches show 100 newest entries instead of blank.
