### PR TITLE
Added hound YAML

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,0 +1,2 @@
+Style/StringLiterals:
+  EnforcedStyle: single_quotes


### PR DESCRIPTION
# Why?
- Enforcing double quotes instead of single quotes is an attack on our way of life as Ruby developers
# What Changed?
- Changed hound.yml to enforce single quotes because, come on, even the rails generators use single quotes.
