### PR TITLE
hero header min-height, margin on alert, min-length before query

### DIFF
--- a/app/assets/javascripts/guides.js
+++ b/app/assets/javascripts/guides.js
@@ -13,17 +13,22 @@ guidesApp.controller('newGuideCtrl', function guidesApp($scope, $http) {
 
   //Typeahead search for crops
   $scope.search = function () {
-    $http({
-      url: '/api/crops',
-      method: "GET",
-      params: {
-        query: $scope.query
-      }
-    }).success(function (r) {
-      $scope.crops = r;
-    }).error(function (r) {
-      alert('Could not retrieve data from server. Please try again later.');
-    });
+    // be nice and only hit the server if
+    // length >= 3
+    if ($scope.query.length >= 3){
+      $http({
+        url: '/api/crops',
+        method: "GET",
+        params: {
+          query: $scope.query
+        }
+      }).success(function (r) {
+        $scope.crops = r;
+        console.log($scope.crops);
+      }).error(function (r) {
+        alert('Could not retrieve data from server. Please try again later.');
+      });
+    }
   };
 
   //Gets fired when user selects dropdown.

--- a/app/assets/stylesheets/alerts.css
+++ b/app/assets/stylesheets/alerts.css
@@ -1,11 +1,11 @@
 .alert {
   /*background: transparent;*/
-  /*margin-bottom: -43px;
-  z-index: 5;*/
+  margin-bottom: -43px;
+  z-index: 5;
 }
 
 .alert-box {
   /*background: transparent;*/
-  /*margin-bottom: -43px;
-  z-index: 5;*/
+  margin-bottom: -43px;
+  z-index: 5;
 }

--- a/app/assets/stylesheets/home.css.scss
+++ b/app/assets/stylesheets/home.css.scss
@@ -1,7 +1,7 @@
 .hero-background {
   width: 100%;
   height: 100%;
-  /*position: fixed;*/
+  min-height: 640px;
   background: image-url('green_wheat_dark10.jpg') no-repeat center center fixed;
   background-size: cover;
 }

--- a/app/views/guides/new.html.erb
+++ b/app/views/guides/new.html.erb
@@ -24,7 +24,7 @@
           typeahead="crop.name for crop in crops" 
           class="form-control"
           ng-selected="testSelection()">
-          <p>Selected crop: {{ new_guide.crop.name }}</p>
+          <p ng-cloak ng-if="new_guide.crop">Selected crop: {{ new_guide.crop.name }}</p>
         <label for="guide_overview">Overview</label>
         <textarea id="guide_overview" name="guide[overview]"
           ng-model="new_guide.overview"></textarea>


### PR DESCRIPTION
Adding a hero header to the min-height so that it doesn't look weird on a smaller screen (min-height 640px)
add the margin back in temporarily. closes #96
Cloak the select statement on page load, and show the selected crop
