### PR TITLE
Re-enable search button

### DIFF
--- a/app/assets/javascripts/home.js
+++ b/app/assets/javascripts/home.js
@@ -1,0 +1,3 @@
+$(window).unload(function() {
+  $.rails.enableFormElements($($.rails.formSubmitSelector));
+});

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -23,6 +23,7 @@
     <%= csrf_meta_tags %>
     <%= javascript_tag "var AUTH_TOKEN = #{form_authenticity_token.inspect};" if protect_against_forgery? %>
     <%= javascript_tag "var USER_ID = '#{current_user.try(:id).to_s}';" if protect_against_forgery? %>
+    <%= javascript_include_tag "application" %>
   </head>
 
   <body>
@@ -117,8 +118,6 @@
         </div>
     <% end %>
     <%= yield %>
-
-    <%= javascript_include_tag "application" %>
     
   </body>
 </html>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -1,3 +1,4 @@
+<%= javascript_include_tag "home" %>
 <div class="hero-background">
     <div class="hero row">
         <div class="small-10 small-centered columns">
@@ -51,4 +52,3 @@
             <a href="https://github.com/farmbot/openfarm">Fork me on GitHub</a>
         </div>
     </div>
-</div>


### PR DESCRIPTION
Problem: if a user clicks the back arrow to search again, the search button will not work. This is caused by the “disable_with” command, the button stays disabled, even after returning to the page.

Let's re-enable it after leaving the page, so that it will be ready for another search. Plus two minor fixes: there was a closing div tag with no counterpart, and javascripts were included at the bottom of the page, blocking the use of included libraries like jQuery for page-specific scripts, like this re-enabling one.
