### PR TITLE
Fix alerts ENV var nil split() issue

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,9 +9,6 @@ class ApplicationController < ActionController::Base
   before_action :set_locale
 
   def default_url_options(options = {})
-    logger.debug "default_url_options is passed options: #{options.inspect}\n"
-    logger.debug params
-    # I18n.locale params['locale']
     { locale: I18n.locale }
   end
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -78,7 +78,7 @@ OpenFarm::Application.configure do
     email: {
       email_prefix: '[OpenFarm Errors] ',
       sender_address: %{"notifier" <notifier@openfarm.cc>},
-      exception_recipients: ENV['ALERTS'].split('|')
+      exception_recipients: ENV['ALERTS'].to_s.split('|')
     },
     ignore_exceptions: ['Mongoid::Errors::DocumentNotFound',
                         'AbstractController::ActionNotFound',

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -78,7 +78,7 @@ OpenFarm::Application.configure do
     email: {
       email_prefix: '[OpenFarm Errors] ',
       sender_address: %{"notifier" <notifier@openfarm.cc>},
-      exception_recipients: ENV['ALERTS'].split('|')
+      exception_recipients: ENV['ALERTS'].to_s.split('|')
     },
     ignore_exceptions: ['Mongoid::Errors::DocumentNotFound',
                         'AbstractController::ActionNotFound',


### PR DESCRIPTION
# Why?
- Just a minor fix for some stuff in production.

Spent most of the morning debugging an issue where Mongoid is refusing to play nicely with Unicorn. Details to follow.
