### PR TITLE
Add typeahead prediction to main search bar

### DIFF
--- a/app/assets/javascripts/search.js
+++ b/app/assets/javascripts/search.js
@@ -1,0 +1,28 @@
+var searchApp = angular.module('searchApp', [
+  'mm.foundation',
+  'ng-rails-csrf'
+  ]);
+
+searchApp.controller('searchCtrl', ['$scope', '$http', '$location',
+  function searchApp($scope, $http, $location) {
+  $scope.crops = [];
+   
+  //Typeahead search for crops    
+  $scope.search = function () {
+    // be nice and only hit the server if
+    // length >= 3
+    if ($scope.query.length >= 3){
+      $http({
+        url: '/api/crops',
+        method: "GET",
+        params: {
+          query: $scope.query
+        }
+      }).success(function (response) {
+        if (response.crops.length){
+          $scope.crops = response.crops;
+        }
+      })
+    }
+  };    
+}]);

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -1,4 +1,5 @@
 <%= javascript_include_tag "home" %>
+<%= javascript_include_tag "search" %>
 <div class="hero-background">
     <div class="hero row">
         <div class="small-10 small-centered columns">
@@ -11,8 +12,15 @@
                 <div class="row">
                     <div class="small-12 small-centered columns">
                         <div class="row collapse">
-                            <div class="small-8 large-9 columns">
-                              <%= f.text_field :q, id: :q, maxlength:"120", class: 'search', placeholder: t('.placeholder') %>
+                            <div class="small-8 large-9 columns ng-cloak"
+                                ng-app="searchApp" 
+                                ng-controller="searchCtrl"
+                                ng-cloak>
+                                
+                                <%= text_field_tag :q, nil, {class: 'search', name: 'cropsearch[q]', placeholder: t('.placeholder'),
+                                    maxlength: '120', autocomplete: 'off', 'ng-model'=>'query', 'ng-change'=>'search()',
+                                    'typeahead'=>'crop.name for crop in crops', 'typeahead-wait-ms'=>'555', 'typeahead-min-length'=>'3'} %>
+
                             </div>
                             <div class="small-4 large-3 columns">
                               <%= f.submit t('.search'), data: { disable_with: "Searching..." }, class: 'button postfix' %>


### PR DESCRIPTION
Implements feature request #148.
# What's new

Main search bar on the homepage suggests crops as user starts typing.
# What's next

Our current search algorithm makes no sense. Results matching all words must have priority, crop names should have higher relevance than descriptions, etc. We need to improve it.
