### PR TITLE
Better HTTP error statuses

### DIFF
--- a/app/mutations/requirements/create_requirement.rb
+++ b/app/mutations/requirements/create_requirement.rb
@@ -23,11 +23,8 @@ module Requirements
 
     def validate_permissions
       if @guide && (@guide.user != user)
-        # TODO: Make a custom 'unauthorized' exception that we can rescue_from
-        # in the controller.
-        add_error :user,
-                  :unauthorized_user,
-                  'You cant create requirements for guides you dont own.'
+        msg = 'You cant create requirements for guides you did not create.'
+        raise OpenfarmErrors::NotAuthorized, msg
       end
     end
 

--- a/app/mutations/requirements/destroy_requirement.rb
+++ b/app/mutations/requirements/destroy_requirement.rb
@@ -16,11 +16,8 @@ module Requirements
 
     def authorize_user
       if @requirement && (@requirement.guide.user != user)
-        # TODO: Make a custom 'unauthorized' exception that we can rescue_from
-        # in the controller.
-        add_error :user,
-                  :unauthorized_user,
-                  'can only destroy requirements that belong to your guides.'
+        msg = 'You can only destroy requirements that belong to your guides.'
+        raise OpenfarmErrors::NotAuthorized, msg
       end
     end
 

--- a/app/mutations/requirements/update_requirement.rb
+++ b/app/mutations/requirements/update_requirement.rb
@@ -22,11 +22,8 @@ module Requirements
 
     def validate_permissions
       if requirement.guide.user != user
-        # TODO: Make a custom 'unauthorized' exception that we can rescue_from
-        # in the controller.
-        add_error :user,
-                  :unauthorized_user,
-                  'You can only update requirements that belong to your guides.'
+        msg = 'You can only update requirements that belong to your guides.'
+        raise OpenfarmErrors::NotAuthorized, msg
       end
     end
 
@@ -34,7 +31,6 @@ module Requirements
       # TODO: Probably a DRYer way of doing this.
       requirement.name        = name if name.present?
       requirement.required    = required if required.present?
-
       requirement.save
     end
   end

--- a/app/mutations/stages/create_stage.rb
+++ b/app/mutations/stages/create_stage.rb
@@ -28,11 +28,8 @@ module Stages
 
     def validate_permissions
       if @guide && (@guide.user != user)
-        # TODO: Make a custom 'unauthorized' exception that we can rescue_from
-        # in the controller.
-        add_error :user,
-                  :unauthorized_user,
-                  'You can only create stages for guides that belong to you.'
+        msg = 'You can only create stages for guides that belong to you.'
+        raise OpenfarmErrors::NotAuthorized, msg
       end
     end
 

--- a/app/mutations/stages/update_stage.rb
+++ b/app/mutations/stages/update_stage.rb
@@ -24,11 +24,8 @@ module Stages
 
     def validate_permissions
       if stage.guide.user != user
-        # TODO: Make a custom 'unauthorized' exception that we can rescue_from
-        # in the controller.
-        add_error :user,
-                  :unauthorized_user,
-                  'You can only update stages that belong to your guides.'
+        msg = 'You can only update stages that belong to your guides.'
+        raise OpenfarmErrors::NotAuthorized, msg
       end
     end
 

--- a/spec/controllers/api/api_requirements_controller_spec.rb
+++ b/spec/controllers/api/api_requirements_controller_spec.rb
@@ -45,8 +45,8 @@ describe Api::RequirementsController, type: :controller do
 
   it 'only allows you to edit your requirements' do
     put :update, id: FactoryGirl.create(:requirement).id, required: 'updated'
-    expect(response.status).to eq(422)
-    expect(json['user']).to eq(
+    expect(response.status).to eq(401)
+    expect(json['error']).to include(
       'You can only update requirements that belong to your guides.')
   end
 
@@ -68,9 +68,9 @@ describe Api::RequirementsController, type: :controller do
              required: true,
              guide_id: FactoryGirl.create(:guide) }
     post :create, data
-    expect(json['user']).to eq(
-      "You cant create requirements for guides you dont own.")
-    expect(response.status).to eq(422)
+    expect(json['error']).to include(
+      "cant create requirements for guides you did not create")
+    expect(response.status).to eq(401)
   end
 
   it 'should update a requirement' do
@@ -86,16 +86,16 @@ describe Api::RequirementsController, type: :controller do
     guide = FactoryGirl.create(:guide)
     requirement = FactoryGirl.create(:requirement, guide: guide)
     put :update, id: requirement.id, required: 'updated'
-    expect(response.status).to eq(422) # WRONG. See TODO in mutation.
+    expect(response.status).to eq(401)
     expect(response.body).to include(
       'You can only update requirements that belong to your guides.')
   end
 
   it 'only destroys requirements owned by the user' do
     delete :destroy, id: FactoryGirl.create(:requirement)
-    expect(json['user']).to eq(
+    expect(json['error']).to include(
       "can only destroy requirements that belong to your guides.")
-    expect(response.status).to eq(422)
+    expect(response.status).to eq(401)
   end
 
   it 'handles deletion of unknown requirements' do

--- a/spec/controllers/api/api_stages_controller_spec.rb
+++ b/spec/controllers/api/api_stages_controller_spec.rb
@@ -65,16 +65,16 @@ describe Api::StagesController, type: :controller do
              guide_id: FactoryGirl.create(:guide).id,
              name: 'hello' }
     post 'create', data, format: :json
-    expect(json['user']).to eq(
+    expect(json['error']).to include(
       "You can only create stages for guides that belong to you.")
-    expect(response.status).to eq(422)
+    expect(response.status).to eq(401)
   end
 
   it 'should not update a stage on someone elses guide' do
     guide = FactoryGirl.create(:guide)
     stage = FactoryGirl.create(:stage, guide: guide)
     put :update, id: stage.id, overview: 'updated'
-    expect(response.status).to eq(422) # WRONG. See TODO in mutation.
+    expect(response.status).to eq(401)
     expect(response.body).to include('You can only update stages that belong to your guides.')
   end
 end


### PR DESCRIPTION
# What's New?
- If a user performed an unauthorized action, we were sending a 422 rather than a 401.
# What's Next?
- Probably token auth expiration handling
