### PR TITLE
dereference IE11 pin thing

### DIFF
--- a/app/views/meta/_global.html.erb
+++ b/app/views/meta/_global.html.erb
@@ -7,5 +7,10 @@
     <meta http-equiv="expires" content="0" />
     <meta name="robots" content="all, follow, index, archive" />
     <meta name="rating" content="general" />
+    
+    <!-- When we're ready for that we can set this to be something that IE11 can do something with:
+    http://msdn.microsoft.com/en-us/library/ie/dn320426(v=vs.85).aspx -->
+    <meta name="msapplication-config" content="none"/>
+
 	<!-- <meta name="author" content="static include organisation-name, publisher name, email@address.xy" /> -->
     <!-- <meta name="copyright" content="fixed 2013 - actual-year-variable [dynamic here!], organisation, license-name, license-link" /> -->


### PR DESCRIPTION
IE11 assumes that we're set up to be pinned to a Windows 8 metro tile. This isn't the case (yet). 
# What's changed
- Just a meta tag that says we don't have a browserconfig file. This is stopgap. Someone should/could probably create one of those.
