### PR TITLE
Ignore ActionView::MissingTemplate

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -24,7 +24,8 @@ OpenFarm::Application.configure do
     ignore_exceptions: ['Mongoid::Errors::DocumentNotFound',
                         'AbstractController::ActionNotFound',
                         'ActionController::RoutingError',
-                        'ActionController::InvalidAuthenticityToken']
+                        'ActionController::InvalidAuthenticityToken',
+                        'ActionView::MissingTemplate']
   config.action_mailer.default_url_options = { host: 'openfarm.cc' }
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.perform_deliveries = true

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -23,7 +23,8 @@ OpenFarm::Application.configure do
     ignore_exceptions: ['Mongoid::Errors::DocumentNotFound',
                         'AbstractController::ActionNotFound',
                         'ActionController::RoutingError',
-                        'ActionController::InvalidAuthenticityToken']
+                        'ActionController::InvalidAuthenticityToken',
+                        'ActionView::MissingTemplate']
   config.action_mailer.default_url_options = { host: 'openfarm.cc' }
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.perform_deliveries = true


### PR DESCRIPTION
# Why?
- `high_voltage` tried to handle unknown URL paths, such as spiders looking for a `rss.xml` file.
- Exception notifier warns us about `ActionView::MissingTemplate'`.
# What Changed?
- Added `ActionView::MissingTemplate'` to list ignored exceptions.
