### PR TITLE
Fix header navigation on smaller screens

### DIFF
--- a/app/assets/stylesheets/_presets.css.scss
+++ b/app/assets/stylesheets/_presets.css.scss
@@ -156,6 +156,20 @@ table{
   width: 100%;
 }
 
+/*
+  Header fixer styles
+*/
+
+.header-search{
+  width: 40%;
+}
+
+@media only screen and (max-width: 40.062em){
+  .header-search{
+    width: 100%;
+  }
+}
+
 /* Section accordion styling */
 .accordion > dd.accordion-navigation > a,
 .accordion > dd.active > a,

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -54,25 +54,6 @@
 
           <section class="top-bar-section">
 
-              <!-- Search box Section -->
-              <%# Added the reference to "/" because root_path was being redefined to have /en|nl/ whichever way I put it. %>
-              <% unless current_page?(root_path) or current_page?("/") %>
-                <form action="<%= crop_search_via_get_path %>" method="get" >
-                  <div class="left">
-
-                    <div class="row collapse postfix-round">
-
-                      <div class="small-4 columns">
-                        <input class="search" id="q" maxlength="120" name="q" placeholder="<%= t('home.placeholder') %>" size="120" type="text">
-                      </div>
-                      <div class="small-2 columns end">
-                        <input class="small button postfix" data-disable-with="Searching..." type="submit" value="<%= t('home.search') %>">
-                      </div>
-                    </div>
-                  </div>
-                </form>
-              <% end %>
-
               <!-- Right Nav Section -->
               <ul class="right">
                   <% if current_user %>
@@ -99,6 +80,29 @@
                       </li>
                   <% end %>
               </ul>
+
+              <!-- Search box Section -->
+              <%# Added the reference to "/" because root_path was being redefined to have /en|nl/ whichever way I put it. %>
+              <% unless current_page?(root_path) or current_page?("/") %>
+                <div class="left header-search">
+                  <form action="<%= crop_search_via_get_path %>" method="get">
+                    
+
+                      <div class="row collapse postfix-round">
+
+                        <div class="small-8 columns">
+                          <input class="search" id="q" maxlength="120" name="q" placeholder="<%= t('home.placeholder') %>" size="120" type="text">
+                        </div>
+                        <div class="small-4 columns end">
+                          <input class="small button postfix" data-disable-with="Searching..." type="submit" value="<%= t('home.search') %>">
+                        </div>
+                      </div>
+                    
+                  </form>
+                </div>
+              <% end %>
+
+              
           </section>
       </nav>
     </div>


### PR DESCRIPTION
Decided to fix this issue which has been around for a while
# What's changed
- re-arranged the top nav bar things so that they're not broken anymore. Fixed the search bar so that it's responsive. Not perfect yet, but now it's a matter of styling.
  ![screenshot 2014-11-30 17 21 50](https://cloud.githubusercontent.com/assets/485583/5237430/91bd2ac2-78b5-11e4-8701-419c5ab6bcbd.png)
  ![screenshot 2014-11-30 17 21 39](https://cloud.githubusercontent.com/assets/485583/5237432/9372825e-78b5-11e4-94c3-151487043070.png)
# What's next
- Continuing to build out the create guide flow. Getting places!
