### PR TITLE
Only reindex in development

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -29,9 +29,6 @@ module OpenFarm
       end
     end
     config.middleware.use Rack::Attack
-    config.after_initialize do
-      Crop.reindex unless Rails.env.test?
-    end
   end
 end
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,3 +1,6 @@
+Crop.reindex
+Guide.reindex
+
 OpenFarm::Application.configure do
   Delayed::Worker.delay_jobs = false
   config.cache_classes = false


### PR DESCRIPTION
# Why?
- For convinience, we were reindexing the `Crop` model in development mode
- This inadvertently was causing excessive reindexing on production and staging, leading to slow deploys and one-off production commands.
# What Changed?
- Added `Guide` to the list of models to be indexed
- Moved it into `development.rb` so it doesn't affect production
