### PR TITLE
Remove history tracker for now

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,6 @@ gem 'aws-sdk', '~> 1.55.0'
 gem 'mutations'
 gem 'rack-attack'
 gem 'impressionist', '~> 1.5.0'
-gem 'mongoid-history'
 gem 'rack-cors', require: 'rack/cors'
 gem 'delayed_job_mongoid'
 gem 'patron' # For searchKick

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -107,7 +107,6 @@ GEM
     diff-lcs (1.2.5)
     doc_yo_self (0.0.1)
     docile (1.1.5)
-    easy_diff (0.0.3)
     elasticsearch (1.0.6)
       elasticsearch-api (= 1.0.6)
       elasticsearch-transport (= 1.0.6)
@@ -168,10 +167,6 @@ GEM
     mime-types (1.25.1)
     mini_portile (0.6.0)
     minitest (4.7.5)
-    mongoid-history (0.4.4)
-      activesupport
-      easy_diff
-      mongoid (>= 3.0)
     mongoid-paperclip (0.0.9)
       paperclip (>= 2.3.6)
     mongoid_slug (3.2.1)
@@ -373,7 +368,6 @@ DEPENDENCIES
   jquery-rails
   launchy
   mongoid!
-  mongoid-history
   mongoid-paperclip
   mongoid_slug
   mutations

--- a/app/models/crop.rb
+++ b/app/models/crop.rb
@@ -5,9 +5,6 @@ class Crop
   include Mongoid::Timestamps
   include Mongoid::Slug
   searchkick
-  # history tracking all Crop documents
-  # note: tracking will not work until #track_history is invoked
-  include Mongoid::History::Trackable
 
   is_impressionable counter_cache: true,
                     column_name: :impressions,
@@ -45,10 +42,4 @@ class Crop
   end
 
   slug :name
-
-
-  # See https://github.com/aq1018/mongoid-history
-  track_history on: [:description, :image],
-                modifier_field: :modifier,
-                version_field: :version
 end

--- a/app/models/history_tracker.rb
+++ b/app/models/history_tracker.rb
@@ -1,3 +1,0 @@
-class HistoryTracker
-  include Mongoid::History::Tracker
-end

--- a/config/initializers/mongoid-history.rb
+++ b/config/initializers/mongoid-history.rb
@@ -1,4 +1,0 @@
-# config/initializers/mongoid-history.rb
-# initializer for mongoid-history
-# assuming HistoryTracker is your tracker class
-Mongoid::History.tracker_class_name = :history_tracker


### PR DESCRIPTION
Although this will need to go back in at some point (it's on the road map), this was added as a feature that was never finished.

Fast forwarding to today, it is causing issues with embedding that can be dealt with later while I try to fix the `missing.png` calamity that is going on right now.

TL;DR: We need history tracking at some point, but it's just bloat right now and is causing some suspect bugs with embedded relations.
