### PR TITLE
Manage crops

### DIFF
--- a/app/assets/javascripts/crops/edit.js
+++ b/app/assets/javascripts/crops/edit.js
@@ -13,7 +13,7 @@ openFarmApp.controller('editCropCtrl', ['$scope', '$http', 'cropService',
       $scope.editCrop.sending = true;
 
       var commonNames = $scope.editCrop.common_names;
-      if (typeof $scope.editCrop.common_names === "string"){
+      if (typeof $scope.editCrop.common_names === 'string'){
         commonNames = $scope.editCrop.common_names.split(/,+|\n+/)
                         .map(function(s){ return s.trim(); });
       }

--- a/app/assets/javascripts/crops/edit.js
+++ b/app/assets/javascripts/crops/edit.js
@@ -11,8 +11,20 @@ openFarmApp.controller('editCropCtrl', ['$scope', '$http', 'cropService',
 
     $scope.submitForm = function(){
       $scope.editCrop.sending = true;
+      var commonNames = [];
+      console.log(typeof $scope.editCrop.common_names);
+      if (typeof $scope.editCrop.common_names === "string"){
+        commonNames = $scope.editCrop.common_names.split(/,+|\n+/)
+                        .map(function(s){ return s.trim(); })
+                        .filter(function(s){ return s.length > 0; });
+      } else {
+        commonNames = $scope.editCrop.common_names
+                        .filter(function(s){ return s.length > 0; });
+      }
+
       var params = {
         crop: {
+          common_names: commonNames,
           name: $scope.editCrop.name,
           description: $scope.editCrop.description || null,
           binomial_name: $scope.editCrop.binomial_name || null,

--- a/app/assets/javascripts/crops/edit.js
+++ b/app/assets/javascripts/crops/edit.js
@@ -11,16 +11,13 @@ openFarmApp.controller('editCropCtrl', ['$scope', '$http', 'cropService',
 
     $scope.submitForm = function(){
       $scope.editCrop.sending = true;
-      var commonNames = [];
-      console.log(typeof $scope.editCrop.common_names);
+
+      var commonNames = $scope.editCrop.common_names;
       if (typeof $scope.editCrop.common_names === "string"){
         commonNames = $scope.editCrop.common_names.split(/,+|\n+/)
-                        .map(function(s){ return s.trim(); })
-                        .filter(function(s){ return s.length > 0; });
-      } else {
-        commonNames = $scope.editCrop.common_names
-                        .filter(function(s){ return s.length > 0; });
+                        .map(function(s){ return s.trim(); });
       }
+      commonNames = commonNames.filter(function(s){ return s.length > 0; });
 
       var params = {
         crop: {

--- a/app/controllers/crops_controller.rb
+++ b/app/controllers/crops_controller.rb
@@ -11,6 +11,7 @@ class CropsController < ApplicationController
 
   def show
     @crop = Crop.find(params[:id])
+    impressionist(@crop, '', unique: [:session_hash])
     @guides = @crop.guides
   end
 

--- a/app/models/crop.rb
+++ b/app/models/crop.rb
@@ -7,9 +7,9 @@ class Crop
   searchkick
 
   is_impressionable counter_cache: true,
-                    column_name: :impressions,
+                    column_name: :impressions_field,
                     unique: :session_hash
-  field :impressions, default: 0
+  field :impressions_field, default: 0
 
   has_many :guides
   field :guides_count, type: Fixnum, default: 0

--- a/app/serializers/crop_serializer.rb
+++ b/app/serializers/crop_serializer.rb
@@ -1,6 +1,7 @@
 class CropSerializer < ApplicationSerializer
-  attributes :_id, :name, :binomial_name, :description, :sun_requirements,
-             :sowing_method, :spread, :days_to_maturity, :row_spacing, :height
+  attributes :_id, :name, :binomial_name, :common_names, :description,
+             :sun_requirements, :sowing_method, :spread, :days_to_maturity,
+             :row_spacing, :height
 
   has_many :pictures
 end

--- a/app/views/crops/edit.html.erb
+++ b/app/views/crops/edit.html.erb
@@ -4,16 +4,16 @@
   <div alerts ng-model="alerts"></div>
 
   <div class="row">
-    <div class="large-8 medium-10 small-12 small-centered columns">
-      <h1>Add a new crop!</h1>
+    <div class="small-8 medium-10 small-12 small-centered columns">
+      <h1>Edit <%= @crop.name %></h1>
     </div>
   </div>
   <form>
     <div class="row">
-      <div class="columns large-4 medium-4">
-        <label class="right" for="crop_name">Crop Name</label>
+      <div class="columns small-4 medium-4">
+        <label class="right" for="crop_name">OpenFarm Crop Name</label>
       </div>
-      <div class="columns large-8 medium-8">
+      <div class="columns small-8 medium-8">
         <input data-ng-model="editCrop.name"
                id="crop_name"
                name="crop[name]"
@@ -22,10 +22,23 @@
     </div>
 
     <div class="row">
-      <div class="columns large-4 medium-4">
+      <div class="columns small-4 medium-4">
+        <label class="right" for="crop_name">Common Names</label>
+      </div>
+      <div class="columns small-8 medium-8">
+        <small>Comma Separated or New Lines</small>
+        <textarea data-ng-model="editCrop.common_names"
+               id="common_names"
+               name="crop[common_names]"
+               type="text"></textarea>
+      </div>
+    </div>
+
+    <div class="row">
+      <div class="columns small-4 medium-4">
         <label class="right" for="binomial_name">Binomial Name</label>
       </div>
-      <div class="columns large-8 medium-8">
+      <div class="columns small-8 medium-8">
         <input data-ng-model="editCrop.binomial_name"
                id="crop_binomial_name"
                name="crop[binomial_name]"
@@ -34,10 +47,10 @@
     </div>
 
     <div class="row">
-      <div class="columns large-4 medium-4">
+      <div class="columns small-4 medium-4">
         <label class="right" for="description">Description</label>
       </div>
-      <div class="columns large-8 medium-8">
+      <div class="columns small-8 medium-8">
         <textarea ng-model="editCrop.description"
                   id="crop_description"
                   name="crop[description]"
@@ -46,22 +59,25 @@
     </div>
 
     <div class="row">
-      <div class="columns large-4 medium-4">
+      <div class="columns small-4 medium-4">
         <label class="right" for="sun_requirements">Sun Requirements</label>
       </div>
-      <div class="columns large-8 medium-8">
-        <input data-ng-model="editCrop.sun_requirements"
-               id="crop_sun_requirements"
-               name="crop[sun_requirements]"
-               type="text"/>
+      <div class="columns small-8 medium-8">
+            <select ng-model="editCrop.sun_requirements"
+                    id="crop_sun_requirements"
+                    name="crop[sun_requirements]">
+              <option value="Full Sun"><%= t('.full_sun') %></option>
+              <option value="Partial Sun"><%= t('.partial_sun') %></option>
+              <option value="Full Shade"><%= t('.full_shade') %></option>
+            </select>
       </div>
     </div>
 
     <div class="row">
-      <div class="columns large-4 medium-4">
+      <div class="columns small-4 medium-4">
         <label class="right" for="sowing_method">Sowing Method</label>
       </div>
-      <div class="columns large-8 medium-8">
+      <div class="columns small-8 medium-8">
         <input data-ng-model="editCrop.sowing_method"
                id="crop_sowing_method"
                name="crop[sowing_method]"
@@ -70,10 +86,10 @@
     </div>
 
     <div class="row">
-      <div class="columns large-4 medium-4">
+      <div class="columns small-4 medium-4">
         <label class="right" for="spread">Spread</label>
       </div>
-      <div class="columns large-8 medium-8">
+      <div class="columns small-8 medium-8">
         <input data-ng-model="editCrop.spread"
                id="crop_spread"
                name="crop[spread]"
@@ -82,46 +98,46 @@
     </div>
 
     <div class="row">
-      <div class="columns large-4 medium-4">
+      <div class="columns small-4 medium-4">
         <label class="right" for="days_to_maturity">Days to Maturity</label>
       </div>
-      <div class="columns large-8 medium-8">
+      <div class="columns small-8 medium-8">
         <input data-ng-model="editCrop.days_to_maturity"
                id="crop_days_to_maturity"
                name="crop[days_to_maturity]"
-               type="text"/>
+               type="number"/>
       </div>
     </div>
 
     <div class="row">
-      <div class="columns large-4 medium-4">
+      <div class="columns small-4 medium-4">
         <label class="right" for="row_spacing">Row Spacing</label>
       </div>
-      <div class="columns large-8 medium-8">
+      <div class="columns small-8 medium-8">
         <input data-ng-model="editCrop.row_spacing"
                id="crop_row_spacing"
                name="crop[row_spacing]"
-               type="text"/>
+               type="number"/>
       </div>
     </div>
 
     <div class="row">
-      <div class="columns large-4 medium-4">
+      <div class="columns small-4 medium-4">
         <label class="right" for="height">Height</label>
       </div>
-      <div class="columns large-8 medium-8">
+      <div class="columns small-8 medium-8">
         <input data-ng-model="editCrop.height"
                id="crop_height"
                name="crop[height]"
-               type="text"/>
+               type="number"/>
       </div>
     </div>
 
     <div class="row">
-      <div class="columns large-4 medium-4">
+      <div class="columns small-4 medium-4">
         <label for="crop[images]" class="right">Manage images</label>
       </div>
-      <div class="columns large-8 medium-8">
+      <div class="columns small-8 medium-8">
         <span ng-repeat="pic in editCrop.pictures"
               class="thumbnails"
               ng-class="{ 'deleted' : pic.deleted }"

--- a/app/views/crops/show.html.erb
+++ b/app/views/crops/show.html.erb
@@ -2,6 +2,9 @@
   <div class="crop-info-container small-6 columns">
     <div class="crop-hero" style="background-image: url('<%= @crop.main_image_path %>')">
       <h1 class="crop-name text-center"><%= @crop.name %></h1>
+      <% if current_user && current_user.admin? %>
+        <%= link_to(icon('edit') + " Edit Crop", {action: 'edit'}, class: 'edit-link button secondary tiny') %>
+      <% end %>
     </div>
     <table class="crop">
         <tbody>

--- a/app/views/guides/show.html.erb
+++ b/app/views/guides/show.html.erb
@@ -58,7 +58,6 @@
 
     <%= render 'guides/show/show_guide_stages' %>
 
-
     </div>
   </div>
 </div>


### PR DESCRIPTION
# What's changed
* Per request, we can now edit common names on the crop edit page. This should allow for bringing together divergent crops.
* We weren't keeping track of crop impressions. Oops.

# What's next
* Once some crops have some data (sowing time, harvest time, etc) on production, I'll pull those into my own localhost and style the timeline bits a bit more.

@roryaronson once this gets sent to master (tomorrow) we could do a data-entry party.