### PR TITLE
406 added .editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+# editorconfig.org
+
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+# Some Markdown editors don't like 2 spaces
+[*.md]
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = false


### PR DESCRIPTION
http://editorconfig.org
2 spaces for everything except markdown, which some editors prefer with 4 spaces (eg nvAlt)