### PR TITLE
Fixing responsiveness of search/crop pages

### DIFF
--- a/app/assets/stylesheets/styles/_crop_searches.css.scss
+++ b/app/assets/stylesheets/styles/_crop_searches.css.scss
@@ -6,17 +6,27 @@
   }
 
   .crop-results-container {
-    height: 100%;
-    overflow-y: scroll;
   }
 
   .guide-results-container {
-    height: 100%;
-    overflow-y: scroll;
     background-color: $openfarm-blue-grey;
     /* replace the typical 15px left/right padding
     to account for the compatibility score bar */
     padding: 0 15px 30px 15px;
+  }
+
+  /* This ensures that on non-mobile screens the two containers
+  show up not only side-by-side but full-height */
+  @media #{$medium-up} {
+    .crop-results-container {
+      height: 100%;
+      overflow-y: scroll;
+    }
+
+    .guide-results-container {
+      height: 100%;
+      overflow-y: scroll;
+    }
   }
 }
 

--- a/app/assets/stylesheets/styles/_crops.css.scss
+++ b/app/assets/stylesheets/styles/_crops.css.scss
@@ -35,9 +35,7 @@
   }
 
   .crop-info-container {
-    height: 100%;
     padding: 0;
-    overflow-y: scroll;
 
     .crop-hero {
       position: relative;
@@ -68,13 +66,30 @@
   }
 
   .guide-results-container {
-    height: 100%;
-    overflow-y: scroll;
     background-color: $openfarm-blue-grey;
 
     h2 {
         margin: 1em 0;
       }
+  }
+
+
+  /* This ensures that on non-mobile screens the two containers
+  show up not only side-by-side but full-height */
+  @media #{$medium-up} {
+    .crop-info-container {
+      height: 100%;
+      overflow-y: scroll;
+
+      .new-crop-button {
+        height: 100px;
+      }
+    }
+
+    .guide-results-container {
+      height: 100%;
+      overflow-y: scroll;
+    }
   }
 }
 

--- a/app/assets/stylesheets/styles/_guides.css.scss
+++ b/app/assets/stylesheets/styles/_guides.css.scss
@@ -193,9 +193,8 @@
     }
 
     .guide-controls {
-      position: absolute;
-      top: 1rem;
-      right: 0;
+      float: right;
+      text-align: right;
     }
   }
 

--- a/app/assets/stylesheets/styles/_nav.css.scss
+++ b/app/assets/stylesheets/styles/_nav.css.scss
@@ -6,7 +6,6 @@
     border-bottom-right-radius: 3px;
     border-bottom-left-radius: 0;
     border-top-left-radius: 0;
-    @include box-shadow(none);
   }
 
   .header-search{

--- a/app/assets/stylesheets/styles/_presets.css.scss
+++ b/app/assets/stylesheets/styles/_presets.css.scss
@@ -156,6 +156,10 @@ textarea {
     letter-spacing: 0.025rem;
   }
 
+  &.no-shadow {
+    @include box-shadow(none);
+  }
+
   &:hover {
     background: $of-green2;
   }

--- a/app/assets/stylesheets/styles/crop_searches/_crop_result.css.scss
+++ b/app/assets/stylesheets/styles/crop_searches/_crop_result.css.scss
@@ -85,7 +85,12 @@
       display: table-cell;
       vertical-align: middle;
       text-align: center;
+    }
 
+    @media #{$small-only} {
+      & {
+        height: 100px;
+      }
     }
   }
 }

--- a/app/views/crop_searches/show.html.erb
+++ b/app/views/crop_searches/show.html.erb
@@ -3,14 +3,14 @@
 <% end %>
 
 <div class="crop-search-results row wide-row">
-  <div class="crop-results-container small-6 columns">
+  <div class="crop-results-container columns medium-6 small-12">
     <h2 class="text-center"><%= t('.choose_a_crop') %></h2>
     <% if @crops.empty? %>
     <p class="no-results, text-center"><%= t('.no_crops') %> "<%= params[:q].to_s %>."<br/><%= t('.would_you_like_to') %> <%= link_to t('.add_this_crop'), new_crop_path %>?</p>
     <% end %>
     <%= render partial: 'crop_results', object: @crops %>
   </div>
-  <div class="guide-results-container small-6 columns">
+  <div class="guide-results-container columns medium-6 small-12">
     <h2 class="text-center"><%= t('.explore_the_guides') %></h2>
     <% if @guides.empty? %>
 

--- a/app/views/crops/show.html.erb
+++ b/app/views/crops/show.html.erb
@@ -1,5 +1,5 @@
 <div class="crop-page row wide-row">
-  <div class="crop-info-container small-6 columns">
+  <div class="crop-info-container columns medium-6 small-12">
     <div class="crop-hero" style="background-image: url('<%= @crop.main_image_path %>')">
       <h1 class="crop-name text-center"><%= @crop.name %></h1>
       <% if current_user && current_user.admin? %>
@@ -45,7 +45,7 @@
         </tbody>
     </table>
   </div>
-  <div class="guide-results-container small-6 columns">
+  <div class="guide-results-container columns medium-6 small-12">
     <h2 class="text-center"><%= @guides.empty? ? "There are no guides for this crop yet" : "Guides for this crop" %></h2>
 
     <% if @guides.empty? %>

--- a/app/views/guides/_guide_result.html.erb
+++ b/app/views/guides/_guide_result.html.erb
@@ -1,5 +1,5 @@
 <%= link_to guide do %>
-  <li class="search-result-guide <%= guide.compatibility_label %>">
+  <li class="search-result-guide compatibility-<%= guide.compatibility_label %>">
     <div class="guide-info">
       <div class="guide-name-and-author">
         <h3 class="guide-name"><%= guide.name %></h3>

--- a/app/views/guides/show.html.erb
+++ b/app/views/guides/show.html.erb
@@ -18,10 +18,6 @@
 
     <div class="row title">
       <div class="columns large-10 large-centered">
-        <div class="">
-          <h1 class="guide-name">{{ guide.name }}</h1>
-          <h2 class="by-line"> <%= t('.guide_by') %> <span>{{ guide.user.display_name }}</span></h2>
-        </div>
         <div class="guide-controls">
           <% if current_user %>
             <button href="#" data-dropdown="addToGarden" aria-controls="addToGarden" aria-expanded="false" class="button tiny secondary dropdown add-to-garden">Add To Garden</button><br>
@@ -39,6 +35,10 @@
           <% if @guide.owned_by?(current_user) %>
             <%= link_to(icon('edit') + " Edit Guide", {:action => 'edit'}, :class=>'button tiny secondary edit-link') %>
           <% end %>
+        </div>
+        <div>
+          <h1 class="guide-name">{{ guide.name }}</h1>
+          <h2 class="by-line"> <%= t('.guide_by') %> <span>{{ guide.user.display_name }}</span></h2>
         </div>
       </div>
     </div>

--- a/app/views/homes/show.html.erb
+++ b/app/views/homes/show.html.erb
@@ -36,7 +36,7 @@
                                     <input typeahead-min-length="3" autocomplete="off" class="search-input ng-pristine ng-valid ng-valid-maxlength ng-touched" id="q" maxlength="120" name="q" ng-change="search()" ng-model="query" placeholder="<%= t('home.placeholder') %>" type="text" typeahead-wait-ms="555" typeahead="crop.name for crop in crops">
                                 </div>
                                 <div class="search-button-container">
-                                    <input class="search-button button postfix" data-disable-with="Searching..." type="submit" value="<%= t('home.search') %>">
+                                    <input class="search-button button no-shadow postfix" data-disable-with="Searching..." type="submit" value="<%= t('home.search') %>">
                                 </div>
                             </div>
                         </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -93,7 +93,7 @@
 
                       </div>
                       <div class="small-4 columns end">
-                        <input class="small button postfix" data-disable-with="Searching..." type="submit" value="<%= t('home.search') %>">
+                        <input class="small button no-shadow postfix" data-disable-with="Searching..." type="submit" value="<%= t('home.search') %>">
                       </div>
                     </div>
                   </form>


### PR DESCRIPTION
* Search and crop pages now stack both columns on small-width screens and shrink the "add crop" button's height.
* Fixed missing color bars on guide results (ooo pretty!)
* Fixed lingering shadow on search bar on home with new `no-shadow` class (I need to create a better fix for this)
* Fixed long guide titles not wrapping around buttons (closes #441)

![screen shot 2015-01-20 at 1 04 39 am](https://cloud.githubusercontent.com/assets/220240/5814451/6482111e-a040-11e4-8ffd-b442fdf3ce52.png)
