### PR TITLE
Use HTTPS for s3 assets

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -36,6 +36,7 @@ OpenFarm::Application.configure do
   options = { storage: :s3,
               path: '/:rails_env/media/:class/:attachment/:id.:extension',
               s3_credentials: { bucket: ENV['S3_BUCKET_NAME'],
+                                s3_protocol: :https,
                                 access_key_id: ENV['SERVER_S3_ACCESS_KEY'],
                                 secret_access_key: ENV['SERVER_S3_SECRET_KEY'] } }
 

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -35,6 +35,7 @@ OpenFarm::Application.configure do
   config.log_formatter = ::Logger::Formatter.new
   options = { storage: :s3,
               path: '/:rails_env/media/:class/:attachment/:id.:extension',
+              s3_protocol: :https,
               s3_credentials: { bucket: ENV['S3_BUCKET_NAME'],
                                 access_key_id: ENV['SERVER_S3_ACCESS_KEY'],
                                 secret_access_key: ENV['SERVER_S3_SECRET_KEY'] } }


### PR DESCRIPTION
# Why?

 * Paperclip was returning `http` asset URLs, but production site forces HTTPS

# What Changed?

 * Change paperclip to return `https` URLs.
