### PR TITLE
increase max image upload size to 25MB Close #396

### DIFF
--- a/app/models/guide.rb
+++ b/app/models/guide.rb
@@ -26,7 +26,7 @@ class Guide
 
   has_mongoid_attached_file :featured_image,
                             default_url: '/assets/leaf-grey.png'
-  validates_attachment_size :featured_image, in: 1.byte..2.megabytes
+  validates_attachment_size :featured_image, in: 1.byte..25.megabytes
   validates_attachment :featured_image,
                        content_type: { content_type:
                          ['image/jpg', 'image/jpeg', 'image/png', 'image/gif'] }

--- a/app/models/picture.rb
+++ b/app/models/picture.rb
@@ -10,7 +10,7 @@ class Picture
               large:  ['500x500>', :jpg] },
     convert_options: { all: '-background transparent -flatten +matte',
                        small: '-gravity center -extent 100x100' }
-  validates_attachment_size :attachment, in: 1.byte..2.megabytes
+  validates_attachment_size :attachment, in: 1.byte..25.megabytes
   validates_attachment :attachment,
                        content_type: { content_type:
                          ['image/jpg', 'image/jpeg', 'image/png', 'image/gif'] }


### PR DESCRIPTION
I couldn't test this locally because of an environment error with S3. Can someone else try uploading an image larger than 2MB?