### PR TITLE
Bump max file size in AWS controller

### DIFF
--- a/app/controllers/api/aws_controller.rb
+++ b/app/controllers/api/aws_controller.rb
@@ -20,7 +20,7 @@ module Api
            { 'acl' => 'public-read' },
            { success_action_status: '201' },
            ['starts-with', '$Content-Type', ''],
-           ['content-length-range', 1, 2 * 1024 * 1024]
+           ['content-length-range', 1, 25.megabytes]
          ]}.to_json).gsub(/\n/, '')
     end
 


### PR DESCRIPTION
# Why?

 * As Simon previously stated, the paperclip image size bump was not enough.

# What's New?

 * I forgot that we had an AWS controller that limited the max upload size. Went ahead and changed that.