### PR TITLE
fix title on edit guide page to say 'Edit' instead of 'Create'

### DIFF
--- a/app/views/guides/edit.html.erb
+++ b/app/views/guides/edit.html.erb
@@ -8,7 +8,7 @@
 <div ng-controller="newGuideCtrl"
      class="guides new-guide" ng-cloak>
 
-  <%= render 'guides/new/new_guide_steps' %>
+  <%= render 'guides/new/new_guide_steps', edit: true %>
 
   <div class="large-8 medium-11 small-12 columns ng-cloak small-centered">
 

--- a/app/views/guides/new/_new_guide_steps.html.erb
+++ b/app/views/guides/new/_new_guide_steps.html.erb
@@ -1,6 +1,14 @@
+<% edit = false if !edit #define edit so that an undefined variable error is not thrown%>
+
 <div class="multi-bar-header">
   <div class="bar-header">
-    <h1 class="title"><%= t('.create_a_growing_guide') %></h1>
+    <h1 class="title">
+      <% if edit %>
+        <%= t('.edit_a_growing_guide') %>
+      <% else %>
+        <%= t('.create_a_growing_guide') %>
+      <% end %>
+    </h1>
   </div>
   <div class="bar-header guide-creation-nav">
     <div class="container">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -213,6 +213,7 @@ en:
           back: "Back"
           new_guide_steps:
               create_a_growing_guide: "Create a Growing Guide"
+              edit_a_growing_guide: "Edit a Growing Guide"
               the_basics: "The Basics"
               life_stages: "Life Stages"
               stage_details: "Stage Details"


### PR DESCRIPTION
In response to Issue #513 

The same template (_new_guide_steps.html.erb) was being used for creating a new guide AND for editing an existing guide. To fix this, a local variable 'edit' is passed to the template when it is rendered for editing. When edit = true, a different title is given which says 'Edit A Growing Guide'