### PR TITLE
Eager load gardens on guide reindex.

### DIFF
--- a/app/jobs/reindex_guides_job.rb
+++ b/app/jobs/reindex_guides_job.rb
@@ -2,6 +2,8 @@ class ReindexGuidesJob < ActiveJob::Base
   queue_as :default
 
   def perform
-    Guide.reindex
+    Guide.desc(:popularity_score).each do |guide|
+      guide.reindex_async
+    end
   end
 end

--- a/app/models/guide.rb
+++ b/app/models/guide.rb
@@ -70,7 +70,7 @@ class Guide
 
     @compatibilities = []
 
-    User.each do |user|
+    User.includes(:gardens).each do |user|
       @compatibilities << {
         user_id: user.id.to_s, score: compatibility_score(user).to_i
       }

--- a/spec/jobs/reindex_guides_job_spec.rb
+++ b/spec/jobs/reindex_guides_job_spec.rb
@@ -2,7 +2,9 @@ require 'spec_helper'
 
 describe ReindexGuidesJob do
   it 'reindexes guides' do
-    expect(Guide).to receive(:reindex)
+    FactoryGirl.create(:guide)
+
+    expect_any_instance_of(Guide).to receive(:reindex_async)
 
     ReindexGuidesJob.new.perform
   end

--- a/spec/models/garden_crop_spec.rb
+++ b/spec/models/garden_crop_spec.rb
@@ -14,7 +14,9 @@ describe GardenCrop do
   end
 
   it 'reindexes guides' do
-    expect(Guide).to receive(:reindex)
+    FactoryGirl.create(:guide)
+
+    expect_any_instance_of(Guide).to receive(:reindex_async)
 
     FactoryGirl.create(:garden, user: FactoryGirl.create(:user))
   end


### PR DESCRIPTION
Here's the benchmarks on my machine for 2000 users.

Before
---------

                  user     system      total        real
    Report:   3.620000   0.500000   4.120000 ( 11.449198)

After
------

                  user     system      total        real
    Report:   0.380000   0.010000   0.390000 (  0.407109)

I also changed how it reindexes after garden saves.  Instead of running the full Guide reindex in a job, it enqueues each guide's reindex as separate jobs spreading the load.

#518 