### PR TITLE
Reference DetailOption instead of hardcode on Guide, purge Requirements

### DIFF
--- a/app/assets/javascripts/guides/new.js
+++ b/app/assets/javascripts/guides/new.js
@@ -214,12 +214,35 @@ openFarmApp.controller('newGuideCtrl', ['$scope', '$http', '$filter',
     $scope.step = +$location.hash() || 1;
   });
 
-  $scope.environmentOptions = ['Potted', 'Outside', 'Greenhouse', 'Inside'];
-  $scope.lightOptions = ['Full Sun', 'Partial Sun', 'Shaded', 'Darkness'];
-  $scope.soilOptions = ['Potting', 'Loam', 'Clay', 'Clay Loam',
-                        'Loamy Sand', 'Sandy Clay', 'Sandy Loam',
-                        'Sandy Clay Loam', 'Sand', 'Silty Clay',
-                        'Silty Clay Loam', 'Silt Loam', 'Silt'];
+  $scope.environmentOptions = [];
+  $scope.lightOptions = [];
+  $scope.soilOptions = [];
+  $scope.practicesOptions = [];
+  var practices = [];
+
+  $http.get('/api/detail_options/')
+    .success(function(response){
+      response.detail_options.forEach(function(detail) {
+        var category = detail.category + "Options";
+        $scope[category].push(detail.name);
+      });
+
+      practices = $scope.practicesOptions.map(function(practice) {
+        return {
+          // TODO: make the slug creation more robust.
+          'slug': practice.toLowerCase(),
+          'label': practice,
+          'selected': false
+        }
+      });
+    })
+    .error(function(r, e){
+      $scope.alerts.push({
+        msg: e,
+        type: 'alert'
+      });
+      console.log(r, e);
+    });
 
   $scope.alerts = [];
   $scope.crops = [];
@@ -232,14 +255,6 @@ openFarmApp.controller('newGuideCtrl', ['$scope', '$http', '$filter',
   $scope.existingGuideID = getIDFromURL('guides');
   $scope.guideExists = ($scope.existingGuideID &&
                         $scope.existingGuideID !== 'new');
-
-  var practices = [
-    {slug: 'organic',      label: 'Organic',      selected: false},
-    {slug: 'permaculture', label: 'Permaculture', selected: false},
-    {slug: 'hydroponic',   label: 'Hydroponic',   selected: false},
-    {slug: 'conventional', label: 'Conventional', selected: false},
-    {slug: 'intensive',    label: 'Intensive',    selected: false}
-  ];
 
   var processCropID = function(crop_id) {
     if (crop_id){

--- a/app/assets/javascripts/guides/new.js
+++ b/app/assets/javascripts/guides/new.js
@@ -223,7 +223,7 @@ openFarmApp.controller('newGuideCtrl', ['$scope', '$http', '$filter',
   $http.get('/api/detail_options/')
     .success(function(response){
       response.detail_options.forEach(function(detail) {
-        var category = detail.category + "Options";
+        var category = detail.category + 'Options';
         $scope[category].push(detail.name);
       });
 
@@ -233,7 +233,7 @@ openFarmApp.controller('newGuideCtrl', ['$scope', '$http', '$filter',
           'slug': practice.toLowerCase(),
           'label': practice,
           'selected': false
-        }
+        };
       });
     })
     .error(function(r, e){

--- a/app/controllers/api/detail_options_controller.rb
+++ b/app/controllers/api/detail_options_controller.rb
@@ -1,0 +1,9 @@
+module Api
+  class DetailOptionsController < Api::Controller
+    skip_before_action :authenticate_from_token!, only: [:index]
+
+    def index
+      render json: DetailOption.all
+    end
+  end
+end

--- a/app/controllers/api/requirement_options_controller.rb
+++ b/app/controllers/api/requirement_options_controller.rb
@@ -2,8 +2,8 @@ module Api
   class RequirementOptionsController < Api::Controller
     skip_before_action :authenticate_from_token!, only: [:index]
 
-    def index
-      render json: RequirementOption.all
-    end
+    # def index
+    #   render json: RequirementOption.all
+    # end
   end
 end

--- a/app/controllers/api/requirements_controller.rb
+++ b/app/controllers/api/requirements_controller.rb
@@ -2,29 +2,29 @@ module Api
   class RequirementsController < Api::Controller
     skip_before_action :authenticate_from_token!, only: [:index, :show]
 
-#     def create
-#       @outcome = Requirements::CreateRequirement.run(params,
-#                                                      user: current_user)
-#       respond_with_mutation(:created)
-#     end
+    #     def create
+    #       @outcome = Requirements::CreateRequirement.run(params,
+    #                                                      user: current_user)
+    #       respond_with_mutation(:created)
+    #     end
 
-#     def show
-#       requirement = Requirement.find(params[:id])
-#       render json: requirement
-#     end
+    #     def show
+    #       requirement = Requirement.find(params[:id])
+    #       render json: requirement
+    #     end
 
-#     def update
-#       requirement = Requirement.find(params[:id])
-#       @outcome = Requirements::UpdateRequirement.run(params,
-#                                                      user: current_user,
-#                                                      requirement: requirement)
-#       respond_with_mutation(:ok)
-#     end
+    #     def update
+    #       requirement = Requirement.find(params[:id])
+    #       @outcome = Requirements::UpdateRequirement.run(params,
+    #                                                    user: current_user,
+    #                                               requirement: requirement)
+    #       respond_with_mutation(:ok)
+    #     end
 
-#     def destroy
-#       @outcome = Requirements::DestroyRequirement.run(params,
-#                                                      user: current_user)
-#       respond_with_mutation(:no_content)
-#     end
+    #     def destroy
+    #       @outcome = Requirements::DestroyRequirement.run(params,
+    #                                                      user: current_user)
+    #       respond_with_mutation(:no_content)
+    #     end
   end
 end

--- a/app/controllers/api/requirements_controller.rb
+++ b/app/controllers/api/requirements_controller.rb
@@ -2,29 +2,29 @@ module Api
   class RequirementsController < Api::Controller
     skip_before_action :authenticate_from_token!, only: [:index, :show]
 
-    def create
-      @outcome = Requirements::CreateRequirement.run(params,
-                                                     user: current_user)
-      respond_with_mutation(:created)
-    end
+#     def create
+#       @outcome = Requirements::CreateRequirement.run(params,
+#                                                      user: current_user)
+#       respond_with_mutation(:created)
+#     end
 
-    def show
-      requirement = Requirement.find(params[:id])
-      render json: requirement
-    end
+#     def show
+#       requirement = Requirement.find(params[:id])
+#       render json: requirement
+#     end
 
-    def update
-      requirement = Requirement.find(params[:id])
-      @outcome = Requirements::UpdateRequirement.run(params,
-                                                     user: current_user,
-                                                     requirement: requirement)
-      respond_with_mutation(:ok)
-    end
+#     def update
+#       requirement = Requirement.find(params[:id])
+#       @outcome = Requirements::UpdateRequirement.run(params,
+#                                                      user: current_user,
+#                                                      requirement: requirement)
+#       respond_with_mutation(:ok)
+#     end
 
-    def destroy
-      @outcome = Requirements::DestroyRequirement.run(params,
-                                                     user: current_user)
-      respond_with_mutation(:no_content)
-    end
+#     def destroy
+#       @outcome = Requirements::DestroyRequirement.run(params,
+#                                                      user: current_user)
+#       respond_with_mutation(:no_content)
+#     end
   end
 end

--- a/app/controllers/requirements_controller.rb
+++ b/app/controllers/requirements_controller.rb
@@ -1,22 +1,23 @@
 class RequirementsController < ApplicationController
-#   def create
-#     @requirement = Requirement.new(requirement_params)
+    #   def create
+    #     @requirement = Requirement.new(requirement_params)
 
-#     #TODO: Assign a slug if none has been given.
+    #     #TODO: Assign a slug if none has been given.
 
-#     if @requirement.save
-#       redirect_to(controller: 'guides',
-#         action: 'edit',
-#         id: @requirement.guide.id)
-#     else
-#       redirect_to(controller: 'guides',
-#         action: 'edit',
-#         id: @requirement.guide.id)
-#     end
-#   end
+    #     if @requirement.save
+    #       redirect_to(controller: 'guides',
+    #         action: 'edit',
+    #         id: @requirement.guide.id)
+    #     else
+    #       redirect_to(controller: 'guides',
+    #         action: 'edit',
+    #         id: @requirement.guide.id)
+    #     end
+    #   end
 
-#   private
-#     def requirement_params
-#       params.require(:requirement).permit(:name, :requirement, :slug, :guide_id)
-#     end
+    #   private
+    #     def requirement_params
+    #       params.require(:requirement).permit(:name,
+    #                                           :requirement, :slug, :guide_id)
+    #     end
 end

--- a/app/controllers/requirements_controller.rb
+++ b/app/controllers/requirements_controller.rb
@@ -1,22 +1,22 @@
 class RequirementsController < ApplicationController
-  def create
-    @requirement = Requirement.new(requirement_params)
+#   def create
+#     @requirement = Requirement.new(requirement_params)
 
-    #TODO: Assign a slug if none has been given. 
-    
-    if @requirement.save
-      redirect_to(controller: 'guides',
-        action: 'edit', 
-        id: @requirement.guide.id)
-    else
-      redirect_to(controller: 'guides',
-        action: 'edit', 
-        id: @requirement.guide.id)
-    end
-  end
+#     #TODO: Assign a slug if none has been given.
 
-  private
-    def requirement_params
-      params.require(:requirement).permit(:name, :requirement, :slug, :guide_id)
-    end
+#     if @requirement.save
+#       redirect_to(controller: 'guides',
+#         action: 'edit',
+#         id: @requirement.guide.id)
+#     else
+#       redirect_to(controller: 'guides',
+#         action: 'edit',
+#         id: @requirement.guide.id)
+#     end
+#   end
+
+#   private
+#     def requirement_params
+#       params.require(:requirement).permit(:name, :requirement, :slug, :guide_id)
+#     end
 end

--- a/app/controllers/requirements_controller.rb
+++ b/app/controllers/requirements_controller.rb
@@ -1,23 +1,23 @@
 class RequirementsController < ApplicationController
-    #   def create
-    #     @requirement = Requirement.new(requirement_params)
+  #   def create
+  #     @requirement = Requirement.new(requirement_params)
 
-    #     #TODO: Assign a slug if none has been given.
+  #     #TODO: Assign a slug if none has been given.
 
-    #     if @requirement.save
-    #       redirect_to(controller: 'guides',
-    #         action: 'edit',
-    #         id: @requirement.guide.id)
-    #     else
-    #       redirect_to(controller: 'guides',
-    #         action: 'edit',
-    #         id: @requirement.guide.id)
-    #     end
-    #   end
+  #     if @requirement.save
+  #       redirect_to(controller: 'guides',
+  #         action: 'edit',
+  #         id: @requirement.guide.id)
+  #     else
+  #       redirect_to(controller: 'guides',
+  #         action: 'edit',
+  #         id: @requirement.guide.id)
+  #     end
+  #   end
 
-    #   private
-    #     def requirement_params
-    #       params.require(:requirement).permit(:name,
-    #                                           :requirement, :slug, :guide_id)
-    #     end
+  #   private
+  #     def requirement_params
+  #       params.require(:requirement).permit(:name,
+  #                                           :requirement, :slug, :guide_id)
+  #     end
 end

--- a/app/models/requirement.rb
+++ b/app/models/requirement.rb
@@ -1,10 +1,10 @@
 class Requirement
-#   include Mongoid::Document
-#   belongs_to :guide
+    # include Mongoid::Document
+    # belongs_to :guide
 
-#   validates_presence_of :guide
+    # validates_presence_of :guide
 
-#   field :name,        type: String
-#   field :required,    type: String
-#   field :slug,        type: String
+    # field :name,        type: String
+    # field :required,    type: String
+    # field :slug,        type: String
 end

--- a/app/models/requirement.rb
+++ b/app/models/requirement.rb
@@ -1,10 +1,10 @@
 class Requirement
-    # include Mongoid::Document
-    # belongs_to :guide
+  # include Mongoid::Document
+  # belongs_to :guide
 
-    # validates_presence_of :guide
+  # validates_presence_of :guide
 
-    # field :name,        type: String
-    # field :required,    type: String
-    # field :slug,        type: String
+  # field :name,        type: String
+  # field :required,    type: String
+  # field :slug,        type: String
 end

--- a/app/models/requirement.rb
+++ b/app/models/requirement.rb
@@ -1,10 +1,10 @@
 class Requirement
-  include Mongoid::Document
-  belongs_to :guide
+#   include Mongoid::Document
+#   belongs_to :guide
 
-  validates_presence_of :guide
+#   validates_presence_of :guide
 
-  field :name,        type: String
-  field :required,    type: String
-  field :slug,        type: String
+#   field :name,        type: String
+#   field :required,    type: String
+#   field :slug,        type: String
 end

--- a/app/models/requirement_option.rb
+++ b/app/models/requirement_option.rb
@@ -1,9 +1,9 @@
-class RequirementOption
-  include Mongoid::Document
+# class RequirementOption
+#   include Mongoid::Document
 
-  field :default_value
-  field :type
-  field :name
-  field :description
-  field :options, type: Array
-end
+#   field :default_value
+#   field :type
+#   field :name
+#   field :description
+#   field :options, type: Array
+# end

--- a/app/mutations/requirements/create_requirement.rb
+++ b/app/mutations/requirements/create_requirement.rb
@@ -1,47 +1,47 @@
-module Requirements
-  class CreateRequirement < Mutations::Command
-    required do
-      model :user
-      string :guide_id
-      string :name
-      string :required
-    end
+# module Requirements
+#   class CreateRequirement < Mutations::Command
+#     required do
+#       model :user
+#       string :guide_id
+#       string :name
+#       string :required
+#     end
 
-    def requirement
-      @requirement ||= Requirement.new
-    end
+#     def requirement
+#       @requirement ||= Requirement.new
+#     end
 
-    def validate
-      validate_guide
-      validate_permissions
-    end
+#     def validate
+#       validate_guide
+#       validate_permissions
+#     end
 
-    def execute
-      set_params
-      requirement
-    end
+#     def execute
+#       set_params
+#       requirement
+#     end
 
-    def validate_guide
-      @guide = Guide.find(guide_id)
-    rescue Mongoid::Errors::DocumentNotFound
-      msg = "Could not find a guide with id #{guide_id}."
-      add_error :guide, :guide_not_found, msg
-    end
+#     def validate_guide
+#       @guide = Guide.find(guide_id)
+#     rescue Mongoid::Errors::DocumentNotFound
+#       msg = "Could not find a guide with id #{guide_id}."
+#       add_error :guide, :guide_not_found, msg
+#     end
 
-    def validate_permissions
-      if @guide && (@guide.user != user)
-        msg = 'You cant create requirements for guides you did not create.'
-        raise OpenfarmErrors::NotAuthorized, msg
-      end
-    end
+#     def validate_permissions
+#       if @guide && (@guide.user != user)
+#         msg = 'You cant create requirements for guides you did not create.'
+#         raise OpenfarmErrors::NotAuthorized, msg
+#       end
+#     end
 
-    def set_params
-      requirement.guide          = @guide
-      # TODO: validate that the stage name is one
-      # of stage options, or should we?
-      requirement.name           = name
-      requirement.required       = required
-      requirement.save
-    end
-  end
-end
+#     def set_params
+#       requirement.guide          = @guide
+#       # TODO: validate that the stage name is one
+#       # of stage options, or should we?
+#       requirement.name           = name
+#       requirement.required       = required
+#       requirement.save
+#     end
+#   end
+# end

--- a/app/mutations/requirements/destroy_requirement.rb
+++ b/app/mutations/requirements/destroy_requirement.rb
@@ -1,31 +1,31 @@
-module Requirements
-  class DestroyRequirement < Mutations::Command
-    required do
-      model :user
-      string :id
-    end
+# module Requirements
+#   class DestroyRequirement < Mutations::Command
+#     required do
+#       model :user
+#       string :id
+#     end
 
-    def validate
-      find_requirement
-      authorize_user
-    end
+#     def validate
+#       find_requirement
+#       authorize_user
+#     end
 
-    def execute
-      @requirement.destroy
-    end
+#     def execute
+#       @requirement.destroy
+#     end
 
-    def authorize_user
-      if @requirement && (@requirement.guide.user != user)
-        msg = 'You can only destroy requirements that belong to your guides.'
-        raise OpenfarmErrors::NotAuthorized, msg
-      end
-    end
+#     def authorize_user
+#       if @requirement && (@requirement.guide.user != user)
+#         msg = 'You can only destroy requirements that belong to your guides.'
+#         raise OpenfarmErrors::NotAuthorized, msg
+#       end
+#     end
 
-    def find_requirement
-      @requirement = Requirement.find(id)
-    rescue Mongoid::Errors::DocumentNotFound
-      msg = "Could not find a requirement with id #{id}."
-      add_error :requirement, :requirement_not_found, msg
-    end
-  end
-end
+#     def find_requirement
+#       @requirement = Requirement.find(id)
+#     rescue Mongoid::Errors::DocumentNotFound
+#       msg = "Could not find a requirement with id #{id}."
+#       add_error :requirement, :requirement_not_found, msg
+#     end
+#   end
+# end

--- a/app/mutations/requirements/update_requirement.rb
+++ b/app/mutations/requirements/update_requirement.rb
@@ -1,37 +1,37 @@
-module Requirements
-  class UpdateRequirement < Mutations::Command
-    required do
-      string :id
-      model :user
-      model :requirement
-    end
+# module Requirements
+#   class UpdateRequirement < Mutations::Command
+#     required do
+#       string :id
+#       model :user
+#       model :requirement
+#     end
 
-    optional do
-      string :name
-      string :required
-    end
+#     optional do
+#       string :name
+#       string :required
+#     end
 
-    def validate
-      validate_permissions
-    end
+#     def validate
+#       validate_permissions
+#     end
 
-    def execute
-      set_valid_params
-      requirement
-    end
+#     def execute
+#       set_valid_params
+#       requirement
+#     end
 
-    def validate_permissions
-      if requirement.guide.user != user
-        msg = 'You can only update requirements that belong to your guides.'
-        raise OpenfarmErrors::NotAuthorized, msg
-      end
-    end
+#     def validate_permissions
+#       if requirement.guide.user != user
+#         msg = 'You can only update requirements that belong to your guides.'
+#         raise OpenfarmErrors::NotAuthorized, msg
+#       end
+#     end
 
-    def set_valid_params
-      # TODO: Probably a DRYer way of doing this. Enforce nil: false, perhaps?
-      requirement.name        = name if name.present?
-      requirement.required    = required if required.present?
-      requirement.save
-    end
-  end
-end
+#     def set_valid_params
+#       # TODO: Probably a DRYer way of doing this. Enforce nil: false, perhaps?
+#       requirement.name        = name if name.present?
+#       requirement.required    = required if required.present?
+#       requirement.save
+#     end
+#   end
+# end

--- a/app/serializers/requirement_option_serializer.rb
+++ b/app/serializers/requirement_option_serializer.rb
@@ -1,8 +1,8 @@
-class RequirementOptionSerializer < ApplicationSerializer
-  attributes :default_value, :type, :name, :options
+# class RequirementOptionSerializer < ApplicationSerializer
+#   attributes :default_value, :type, :name, :options
 
-  def options
-    object.options.to_a
-  end
+#   def options
+#     object.options.to_a
+#   end
 
-end
+# end

--- a/app/serializers/requirement_serializer.rb
+++ b/app/serializers/requirement_serializer.rb
@@ -1,3 +1,3 @@
-class RequirementSerializer < ApplicationSerializer
-  attributes :_id, :guide, :name, :required
-end
+# class RequirementSerializer < ApplicationSerializer
+#   attributes :_id, :guide, :name, :required
+# end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -40,11 +40,13 @@ OpenFarm::Application.routes.draw do
                                       :update,
                                       :destroy]
     end
-    resources :requirement_options, only: [:index]
+    # resources :requirement_options, only: [:index]
+    # resources :requirements, only: [:create, :show, :update, :destroy]
+    resources :detail_options, only: [:index]
     resources :stage_options, only: [:index]
     resources :stage_action_options, only: [:index]
     resources :stages, only: [:create, :show, :update, :destroy]
-    resources :requirements, only: [:create, :show, :update, :destroy]
+
     # TODO Figure out why I can't use a singular resource route here.
     post 'token', to: 'tokens#create'
     delete 'token', to: 'tokens#destroy'

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -54,10 +54,7 @@ if Rails.env != 'production' # <= Prevent catastrophe
   FactoryGirl.create(:detail_option, name: 'Potted', category: 'environment')
   FactoryGirl.create(:detail_option, name: 'Inside', category: 'environment')
   FactoryGirl.create(:detail_option, name: 'Inside', category: 'environment')
-  outside = FactoryGirl.create(:detail_option,
-                               name: 'Outside',
-                               category: 'environment')
-
+  FactoryGirl.create(:detail_option, name: 'Outside', category: 'environment')
 
   FactoryGirl.create(:detail_option, name: 'Loam', category: 'soil')
   FactoryGirl.create(:detail_option, name: 'Clay', category: 'soil')
@@ -76,7 +73,6 @@ if Rails.env != 'production' # <= Prevent catastrophe
   FactoryGirl.create(:detail_option,
                      name: 'Permaculture',
                      category: 'practices')
-
 
   prep = FactoryGirl.create(:stage_option, name: 'Preparation', order: 0)
   prep.stage_action_options = [water, fertilize, amend, prepare]
@@ -106,8 +102,6 @@ if Rails.env != 'production' # <= Prevent catastrophe
 
   dormant = FactoryGirl.create(:stage_option, name: 'Dormant', order: 8)
   dormant.stage_action_options = [prune, cover, tap]
-
-
 
   Guide.all.each{ |gde| gde.update_attributes(user: admin) }
 end

--- a/spec/controllers/api/api_requirement_options_controller_spec.rb
+++ b/spec/controllers/api/api_requirement_options_controller_spec.rb
@@ -1,21 +1,21 @@
 require 'spec_helper'
 
 describe Api::RequirementOptionsController, type: :controller do
-  include ApiHelpers
+  # include ApiHelpers
 
-  let(:user) {sign_in(user = FactoryGirl.create(:user)) && user }
-  let(:requirement_option) { FactoryGirl.create(:requirement_option_range) }
-  let(:requirement_option) { FactoryGirl.create(:requirement_option_select) }
-  
-  before do
-    FactoryGirl.create_list(:requirement_option_range, 4)
-    FactoryGirl.create_list(:requirement_option_select, 2)
-  end
+  # let(:user) {sign_in(user = FactoryGirl.create(:user)) && user }
+  # let(:requirement_option) { FactoryGirl.create(:requirement_option_range) }
+  # let(:requirement_option) { FactoryGirl.create(:requirement_option_select) }
 
-  it 'lists requirement options' do
-    get 'index', format: :json
-    expect(response.status).to eq(200)
-    expect(json['requirement_options'].length).to eq(RequirementOption.all.length)
-  end
+  # before do
+  #   FactoryGirl.create_list(:requirement_option_range, 4)
+  #   FactoryGirl.create_list(:requirement_option_select, 2)
+  # end
+
+  # it 'lists requirement options' do
+  #   get 'index', format: :json
+  #   expect(response.status).to eq(200)
+  #   expect(json['requirement_options'].length).to eq(RequirementOption.all.length)
+  # end
 
 end

--- a/spec/controllers/api/api_requirement_options_controller_spec.rb
+++ b/spec/controllers/api/api_requirement_options_controller_spec.rb
@@ -15,7 +15,7 @@ describe Api::RequirementOptionsController, type: :controller do
   # it 'lists requirement options' do
   #   get 'index', format: :json
   #   expect(response.status).to eq(200)
-  #   expect(json['requirement_options'].length).to eq(RequirementOption.all.length)
+  #   expect(json['requirement_options'].length).to
+  #      eq(RequirementOption.all.length)
   # end
-
 end

--- a/spec/controllers/api/api_requirements_controller_spec.rb
+++ b/spec/controllers/api/api_requirements_controller_spec.rb
@@ -1,106 +1,106 @@
 require 'spec_helper'
 
 describe Api::RequirementsController, type: :controller do
-  include ApiHelpers
+  # include ApiHelpers
 
-  let!(:user) { sign_in(user = FactoryGirl.create(:user)) && user }
-  let(:guide) { FactoryGirl.create(:guide, user: user) }
+  # let!(:user) { sign_in(user = FactoryGirl.create(:user)) && user }
+  # let(:guide) { FactoryGirl.create(:guide, user: user) }
 
-  before do
-    @guide = FactoryGirl.create(:guide, name: 'lee\'s mung bean')
-  end
+  # before do
+  #   @guide = FactoryGirl.create(:guide, name: 'lee\'s mung bean')
+  # end
 
-  it 'creates requirements' do
-    guide = FactoryGirl.create(:guide, user: user)
-    old_length = Requirement.all.length
-    data = { name: Faker::Lorem.word,
-             required: "#{Faker::Lorem.words(2)}",
-             guide_id: guide.id }
-    post :create, data, format: :json
-    expect(response.status).to eq(201)
-    new_length = Requirement.all.length
-    expect(new_length).to eq(old_length + 1)
-  end
+  # it 'creates requirements' do
+  #   guide = FactoryGirl.create(:guide, user: user)
+  #   old_length = Requirement.all.length
+  #   data = { name: Faker::Lorem.word,
+  #            required: "#{Faker::Lorem.words(2)}",
+  #            guide_id: guide.id }
+  #   post :create, data, format: :json
+  #   expect(response.status).to eq(201)
+  #   new_length = Requirement.all.length
+  #   expect(new_length).to eq(old_length + 1)
+  # end
 
-  it 'deletes requirements' do
-    guide = FactoryGirl.create(:guide, user: user)
-    requirement = FactoryGirl.create(:requirement, guide: guide)
-    old_length = Requirement.all.length
-    delete 'destroy', id: requirement.id, format: :json
-    new_length = Requirement.all.length
-    expect(new_length).to eq(old_length - 1)
-  end
+  # it 'deletes requirements' do
+  #   guide = FactoryGirl.create(:guide, user: user)
+  #   requirement = FactoryGirl.create(:requirement, guide: guide)
+  #   old_length = Requirement.all.length
+  #   delete 'destroy', id: requirement.id, format: :json
+  #   new_length = Requirement.all.length
+  #   expect(new_length).to eq(old_length - 1)
+  # end
 
-  it 'should return an error when wrong info is passed to create' do
-    # FIXME reword this to better describe whats going on or make assertions on
-    # the response body text.
-    data = {
-      required: "#{Faker::Lorem.sentences(2)}",
-      guide_id: guide.id
-    }
-    post :create, data, format: :json
-    expect(response.status).to eq(422)
-  end
+  # it 'should return an error when wrong info is passed to create' do
+  #   # FIXME reword this to better describe whats going on or make assertions on
+  #   # the response body text.
+  #   data = {
+  #     required: "#{Faker::Lorem.sentences(2)}",
+  #     guide_id: guide.id
+  #   }
+  #   post :create, data, format: :json
+  #   expect(response.status).to eq(422)
+  # end
 
-  it 'only allows you to edit your requirements' do
-    put :update, id: FactoryGirl.create(:requirement).id, required: 'updated'
-    expect(response.status).to eq(401)
-    expect(json['error']).to include(
-      'You can only update requirements that belong to your guides.')
-  end
+  # it 'only allows you to edit your requirements' do
+  #   put :update, id: FactoryGirl.create(:requirement).id, required: 'updated'
+  #   expect(response.status).to eq(401)
+  #   expect(json['error']).to include(
+  #     'You can only update requirements that belong to your guides.')
+  # end
 
-  it 'should show a specific requirements' do
-    requirement = FactoryGirl.create(:requirement)
-    get :show, id: requirement.id, format: :json
-    expect(response.status).to eq(200)
-    expect(json['requirement']['name']).to eq(requirement.name)
-  end
+  # it 'should show a specific requirements' do
+  #   requirement = FactoryGirl.create(:requirement)
+  #   get :show, id: requirement.id, format: :json
+  #   expect(response.status).to eq(200)
+  #   expect(json['requirement']['name']).to eq(requirement.name)
+  # end
 
-  it 'should return a not found error if a guide is not found' do
-    post :create, name: 'sunlight', required: true, guide_id: 1
-    expect(json["guide"]).to eq("Could not find a guide with id 1.")
-    expect(response.status).to eq(422)
-  end
+  # it 'should return a not found error if a guide is not found' do
+  #   post :create, name: 'sunlight', required: true, guide_id: 1
+  #   expect(json["guide"]).to eq("Could not find a guide with id 1.")
+  #   expect(response.status).to eq(422)
+  # end
 
-  it 'does not allow adding requirements to other peoples guides' do
-    data = { name: 'sunlight',
-             required: true,
-             guide_id: FactoryGirl.create(:guide) }
-    post :create, data
-    expect(json['error']).to include(
-      "cant create requirements for guides you did not create")
-    expect(response.status).to eq(401)
-  end
+  # it 'does not allow adding requirements to other peoples guides' do
+  #   data = { name: 'sunlight',
+  #            required: true,
+  #            guide_id: FactoryGirl.create(:guide) }
+  #   post :create, data
+  #   expect(json['error']).to include(
+  #     "cant create requirements for guides you did not create")
+  #   expect(response.status).to eq(401)
+  # end
 
-  it 'should update a requirement' do
-    guide = FactoryGirl.create(:guide, user: user)
-    requirement = FactoryGirl.create(:requirement, guide: guide)
-    put :update, id: requirement.id, required: 'updated'
-    expect(response.status).to eq(200)
-    requirement.reload
-    expect(requirement.required).to eq('updated')
-  end
+  # it 'should update a requirement' do
+  #   guide = FactoryGirl.create(:guide, user: user)
+  #   requirement = FactoryGirl.create(:requirement, guide: guide)
+  #   put :update, id: requirement.id, required: 'updated'
+  #   expect(response.status).to eq(200)
+  #   requirement.reload
+  #   expect(requirement.required).to eq('updated')
+  # end
 
-  it 'should not update a requirement on someone elses guide' do
-    guide = FactoryGirl.create(:guide)
-    requirement = FactoryGirl.create(:requirement, guide: guide)
-    put :update, id: requirement.id, required: 'updated'
-    expect(response.status).to eq(401)
-    expect(response.body).to include(
-      'You can only update requirements that belong to your guides.')
-  end
+  # it 'should not update a requirement on someone elses guide' do
+  #   guide = FactoryGirl.create(:guide)
+  #   requirement = FactoryGirl.create(:requirement, guide: guide)
+  #   put :update, id: requirement.id, required: 'updated'
+  #   expect(response.status).to eq(401)
+  #   expect(response.body).to include(
+  #     'You can only update requirements that belong to your guides.')
+  # end
 
-  it 'only destroys requirements owned by the user' do
-    delete :destroy, id: FactoryGirl.create(:requirement)
-    expect(json['error']).to include(
-      "can only destroy requirements that belong to your guides.")
-    expect(response.status).to eq(401)
-  end
+  # it 'only destroys requirements owned by the user' do
+  #   delete :destroy, id: FactoryGirl.create(:requirement)
+  #   expect(json['error']).to include(
+  #     "can only destroy requirements that belong to your guides.")
+  #   expect(response.status).to eq(401)
+  # end
 
-  it 'handles deletion of unknown requirements' do
-    delete :destroy, id: 1
-    expect(json['requirement']).to eq("Could not find a requirement with id 1.")
-    expect(response.status).to eq(422)
-  end
+  # it 'handles deletion of unknown requirements' do
+  #   delete :destroy, id: 1
+  #   expect(json['requirement']).to eq("Could not find a requirement with id 1.")
+  #   expect(response.status).to eq(422)
+  # end
 
 end

--- a/spec/controllers/api/api_requirements_controller_spec.rb
+++ b/spec/controllers/api/api_requirements_controller_spec.rb
@@ -32,7 +32,8 @@ describe Api::RequirementsController, type: :controller do
   # end
 
   # it 'should return an error when wrong info is passed to create' do
-  #   # FIXME reword this to better describe whats going on or make assertions on
+  #   # FIXME reword this to better describe whats going on or make assertions
+  # on
   #   # the response body text.
   #   data = {
   #     required: "#{Faker::Lorem.sentences(2)}",
@@ -99,8 +100,8 @@ describe Api::RequirementsController, type: :controller do
 
   # it 'handles deletion of unknown requirements' do
   #   delete :destroy, id: 1
-  #   expect(json['requirement']).to eq("Could not find a requirement with id 1.")
+  #   expect(json['requirement'])
+  #     .to eq("Could not find a requirement with id 1.")
   #   expect(response.status).to eq(422)
   # end
-
 end

--- a/spec/models/guide_spec.rb
+++ b/spec/models/guide_spec.rb
@@ -99,7 +99,7 @@ describe Guide do
     FactoryGirl.create(:guide)
     guide = FactoryGirl.create(:guide)
     existing_score = guide.popularity_score
-    guide.impressions_field = 20 # Note: guide factory can randomly create 20
+    guide.impressions_field = 110
     guide.save
     expect(guide.popularity_score).not_to eq(0)
     expect(guide.popularity_score).not_to eq(existing_score)

--- a/test/factories/detail_options.rb
+++ b/test/factories/detail_options.rb
@@ -1,8 +1,8 @@
 FactoryGirl.define do
   factory :detail_option do
-    name             { "#{Faker::Name.last_name}" }
-    description      { Faker::Lorem.sentence }
-    help             { Faker::Lorem.sentence }
-    category         { "#{Faker::Lorem.word}" }
+    name        { "#{Faker::Name.last_name}" }
+    description { Faker::Lorem.sentence }
+    help        { Faker::Lorem.sentence }
+    category    { "#{Faker::Lorem.word}" }
   end
 end


### PR DESCRIPTION
# What's Changed
* We don't use requirements anymore. Get rid of them (commented for now, can delete once tested).
* On Guide.new.js make sure we're using DetailOption. *Note* only pull this in once we've populated the database with the necessary options on live / staging.