### PR TITLE
Run Docker image with tmp/pids/docker.pid as pid file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,5 +30,5 @@ ADD     . /openfarm
 # Environment is passed in from the host environment, disable the warning
 RUN     touch /openfarm/config/app_environment_variables.rb
 
-CMD     bundle exec rails server
+CMD     ["bundle", "exec", "rails", "server", "-P", "tmp/pids/docker.pid"]
 EXPOSE  3000


### PR DESCRIPTION
I'm not too fond of the excessively long `CMD`, but I didn't see any way other than passing `-P` to set a pid file (I was hoping for `RAILS_PID=tmp/pids/docker.pid` or something).

It might be worth exploring whether having a smarter `config.ru` and changing the Dockerfile to have `CMD ["bundle", "exec", "rackup"]` could improve the situation, assuming this could be done in a way that wouldn't interfere with staging/production deployments of OpenFarm.