### PR TITLE
Fix missing medium compatibility color

### DIFF
--- a/app/assets/stylesheets/styles/_variables.scss
+++ b/app/assets/stylesheets/styles/_variables.scss
@@ -35,11 +35,11 @@ $openfarm-green-muted: #99b36c;
 $openfarm-blue-grey:   #eceff0;
 
 $compatibility-low-color:  #b23a2c;
-$compatibility-med-color:  #fbad2f;
+$compatibility-medium-color:  #fbad2f;
 $compatibility-high-color: #84c93f;
  /* Same color, just lighter (adjusted to appear perceptually equally lighter) */
 $compatibility-low-color-bg:  lighten($compatibility-low-color, 45%);
-$compatibility-med-color-bg:  lighten($compatibility-med-color, 35%);
+$compatibility-medium-color-bg:  lighten($compatibility-medium-color, 35%);
 $compatibility-high-color-bg: lighten($compatibility-high-color, 40%);
 
 /* Ceci, n'est pas un couleur */

--- a/app/assets/stylesheets/styles/components/crop_searches/_guide_result.css.scss
+++ b/app/assets/stylesheets/styles/components/crop_searches/_guide_result.css.scss
@@ -29,7 +29,7 @@
   }
 
   @include compatibility-color('compatibility-low', $compatibility-low-color);
-  @include compatibility-color('compatibility-med', $compatibility-med-color);
+  @include compatibility-color('compatibility-medium', $compatibility-medium-color);
   @include compatibility-color('compatibility-high', $compatibility-high-color);
 
   &:hover {

--- a/app/assets/stylesheets/styles/components/guides/_guides.css.scss
+++ b/app/assets/stylesheets/styles/components/guides/_guides.css.scss
@@ -401,7 +401,7 @@
         }
 
         &.medium {
-          background: $compatibility-med-color-bg;
+          background: $compatibility-medium-color-bg;
         }
 
         &.high {

--- a/app/assets/stylesheets/styles/ui/_compatibility_circle.css.scss
+++ b/app/assets/stylesheets/styles/ui/_compatibility_circle.css.scss
@@ -30,6 +30,6 @@
   }
 
   @include compatibility-color('low', $compatibility-low-color);
-  @include compatibility-color('medium', $compatibility-med-color);
+  @include compatibility-color('medium', $compatibility-medium-color);
   @include compatibility-color('high', $compatibility-high-color);
 }


### PR DESCRIPTION
Closes #579. Decided to change `med` to `medium` to match `low` and `high`. Fully words == less ambiguity …generally.