### PR TITLE
Go to crop page when user clicks on typeahead search. Resolves #601

### DIFF
--- a/app/assets/javascripts/search.js
+++ b/app/assets/javascripts/search.js
@@ -19,5 +19,14 @@ openFarmApp.controller('searchCtrl', ['$scope', '$http',
         }
       });
     }
-  };    
+  };   
+
+  // Redirect the browser to a specified crop
+  //
+  // pathTemplate is a string template for a crop path, 
+  //              with the text "ID" representing where the url slug should go
+  $scope.goToCrop = function (crop, pathTemplate) {
+    var slug = crop._slugs.length > 0 ? crop._slugs[0] : crop._id;
+    location.assign( pathTemplate.replace('ID', slug) );
+  };
 }]);

--- a/app/views/homes/show.html.erb
+++ b/app/views/homes/show.html.erb
@@ -19,12 +19,12 @@
         </button></a>
     </div>
     <div class="search text-center">
-        <form action="<%= crop_search_via_get_path %>" method="get" >
+        <form action="<%= crop_search_via_get_path %>" method="get">
         <!-- ^NOT A MISTAKE!! Avoiding rails helpers for cleaner URLs and Ganalytics. -->
             <div class="search-bar-container">
-                <div class="search-bar" ng-app="searchApp" ng-controller="searchCtrl">
+                <div class="search-bar" ng-app="searchApp" ng-controller="searchCtrl" >
                     <div class="search-input-container">
-                        <input typeahead-min-length="1" autocomplete="off" class="search-input ng-pristine ng-valid ng-valid-maxlength ng-touched" id="q" maxlength="120" name="q" ng-change="search()" ng-model="query" placeholder="<%= t('home.placeholder') %>" type="text" typeahead-wait-ms="200" typeahead="crop.name for crop in crops">
+                        <input typeahead-min-length="1" autocomplete="off" class="search-input ng-pristine ng-valid ng-valid-maxlength ng-touched" id="q" maxlength="120" name="q" ng-change="search()" ng-model="query" placeholder="<%= t('home.placeholder') %>" type="text" typeahead-wait-ms="200" typeahead="crop.name for crop in crops" typeahead-on-select='goToCrop($item, "<%= crop_path("ID") %>")'>
                     </div>
                     <div class="search-button-container">
                         <input class="search-button button no-shadow postfix" data-disable-with="Searching..." type="submit" value="<%= t('home.search') %>">


### PR DESCRIPTION
Eg; http://recordit.co/Ej1jExXUIb

Uses a somewhat roundabout method to avoid duplicating route information
into the static javascript pages - the view generates a path template that
it passes to the static JS.

The js-routes gem seems it might provide a cleaner approach, but it came
with a series of caveats about production problems. Pragmatism and all that,
this seemed like a useful way to do it - ceveat that I've never used rails,
so I may be missing something obvious.