### PR TITLE
Add VCR For Mailchimp Access, Restructure Crop Data #614

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,7 +54,6 @@ group :development, :test do
   gem 'launchy'
   gem 'factory_girl_rails'
   gem 'faker'
-  gem 'webmock'
 end
 
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -54,6 +54,7 @@ group :development, :test do
   gem 'launchy'
   gem 'factory_girl_rails'
   gem 'faker'
+  gem 'webmock'
 end
 
 group :test do

--- a/app/models/crop.rb
+++ b/app/models/crop.rb
@@ -14,10 +14,6 @@ class Crop
   has_many :guides
   field :guides_count, type: Fixnum, default: 0
 
-  field :name
-  field :common_names, type: Array
-  validates_presence_of :name
-  field :binomial_name
   field :description
   belongs_to :crop_data_source
   field :sun_requirements
@@ -27,6 +23,22 @@ class Crop
   field :minimum_temperature, type: Integer # In Celcius
   field :row_spacing, type: Integer
   field :height, type: Integer
+
+  # Naming. This is tricky.
+  # See https://github.com/openfarmcc/OpenFarm/issues/641
+  field :binomial_name
+
+  field :genus
+  field :species
+
+  field :cultivar_name
+
+  field :name
+  field :common_names, type: Array
+  validates_presence_of :name
+
+  has_many :varieties, class_name: 'Crop'
+  belongs_to :parent, class_name: 'Crop'
 
   # embeds_many :crop_times
 

--- a/app/models/crop.rb
+++ b/app/models/crop.rb
@@ -37,8 +37,8 @@ class Crop
   field :common_names, type: Array
   validates_presence_of :name
 
-  has_many :varieties, class_name: 'Crop'
-  belongs_to :parent, class_name: 'Crop'
+  # has_many :varieties, class_name: Crop
+  # belongs_to :parent, class_name: Crop
 
   # embeds_many :crop_times
 

--- a/app/models/crop.rb
+++ b/app/models/crop.rb
@@ -35,10 +35,10 @@ class Crop
 
   field :name
   field :common_names, type: Array
-  validates_presence_of :name
+  validates :name, presence: true
 
-  # has_many :varieties, class_name: Crop
-  # belongs_to :parent, class_name: Crop
+  has_many :varieties, class_name: 'Crop', inverse_of: :parent
+  belongs_to :parent, class_name: 'Crop', inverse_of: :varieties
 
   # embeds_many :crop_times
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -82,20 +82,20 @@ class User
     gb = Gibbon::API.new
     if self.mailing_list && self.confirmed?
       list = gb.lists.list({ filters: { list_name: 'OpenFarm Subscribers' } })
-      gb.lists.subscribe({ id: list['data'][0]['id'],
-                           email: { email: self[:email] },
-                           merge_vars: { :DNAME => self[:display_name] },
-                           double_optin: false,
-                           update_existing: true })
+      gb.lists.subscribe(id: list['data'][0]['id'],
+                         email: { email: self[:email] },
+                         merge_vars: { DNAME: self[:display_name] },
+                         double_optin: false,
+                         update_existing: true)
 
     end
     if self.help_list && self.confirmed?
       list = gb.lists.list({ filters: { list_name: 'OpenFarm Helpers' } })
-      gb.lists.subscribe({ id: list['data'][0]['id'],
-                           email: { email: self[:email] },
-                           merge_vars: { :DNAME => self[:display_name] },
-                           double_optin: false,
-                           update_existing: true })
+      gb.lists.subscribe(id: list['data'][0]['id'],
+                         email: { email: self[:email] },
+                         merge_vars: { DNAME: self[:display_name] },
+                         double_optin: false,
+                         update_existing: true)
 
     end
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -91,7 +91,7 @@ class User
     end
     if self.help_list && self.confirmed?
       list = gb.lists.list({ filters: { list_name: 'OpenFarm Helpers' } })
-      gb.lists.subscribe({ id: self['data'][0]['id'],
+      gb.lists.subscribe({ id: list['data'][0]['id'],
                            email: { email: self[:email] },
                            merge_vars: { :DNAME => self[:display_name] },
                            double_optin: false,

--- a/spec/features/user_sessions_spec.rb
+++ b/spec/features/user_sessions_spec.rb
@@ -91,13 +91,13 @@ describe 'User sessions' do
   end
 
   it 'should link to mailchimp if user chooses to be on mailing list'  # do
-    # usr = sign_up_procedure
+  #   usr = sign_up_procedure
 
-    # choose('yes-email')
+  #   choose('yes-email')
 
-    # click_button I18n::t('users.finish.next_step')
+  #   click_button I18n::t('users.finish.next_step')
 
-    # expect(usr.mailing_list).to eq(true)
+  #   expect(usr.mailing_list).to eq(true)
   # end
 
   it 'should link to mailchimp if user chooses to be on mailing list'  # do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -10,4 +10,24 @@ describe User do
     expect(FactoryGirl.build(:confirmed_user, email: nil)).to_not be_valid
     expect(FactoryGirl.build(:confirmed_user, display_name: nil)).to_not be_valid
   end
+
+  it 'should connect to mailchimp if mailing list and confirmed' do
+    VCR.use_cassette('models/user_spec/mailing_list') do
+      # These tests are pretty meaningless with the VCR, but we also don't
+      # want to add fake sign-ups every time tests are run.
+      user = FactoryGirl.create(:confirmed_user)
+      user.mailing_list = true
+      user.save
+    end
+  end
+
+  it 'should connect to mailchimp if help list and confirmed' do
+    VCR.use_cassette('models/user_spec/help_list') do
+      # These tests are pretty meaningless with the VCR, but we also don't
+      # want to add fake sign-ups every time tests are run.
+      user = FactoryGirl.create(:confirmed_user)
+      user.help_list = true
+      user.save
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,6 +21,7 @@ require 'rspec/rails'
 require 'capybara/rails'
 require 'webmock/rspec'
 require 'vcr'
+require 'webmock/rspec'
 require 'pundit/rspec'
 # ====== PHANTOMJS stuff
 require 'capybara/poltergeist'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -92,6 +92,10 @@ RSpec.configure do |config|
   end
 end
 
+Gibbon::Export.new(ENV['MAILCHIMP_API_KEY'])
+Gibbon::Export.timeout = 15
+Gibbon::Export.throws_exceptions = false
+
 class ActionController::TestCase
   include Devise::TestHelpers
 end

--- a/vcr/models/user_spec/help_list.yml
+++ b/vcr/models/user_spec/help_list.yml
@@ -1,0 +1,69 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://us8.api.mailchimp.com/2.0/lists/list
+    body:
+      encoding: UTF-8
+      string: '{"apikey":"","filters":{"list_name":"OpenFarm
+        Helpers"}}'
+    headers: {}
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '930'
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Mon, 06 Jul 2015 05:36:27 GMT
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - _AVESTA_ENVIRONMENT=prod; path=/
+    body:
+      encoding: UTF-8
+      string: '{"total":1,"data":[{"id":"7ec999ba49","web_id":540717,"name":"OpenFarm
+        Helpers","date_created":"2015-04-03 08:25:15","email_type_option":false,"use_awesomebar":true,"default_from_name":"The
+        OpenFarm Team","default_from_email":"kevin@openfarm.cc","default_subject":"","default_language":"en","list_rating":0,"subscribe_url_short":"http:\/\/eepurl.com\/biTabv","subscribe_url_long":"http:\/\/openfarm.us8.list-manage.com\/subscribe?u=&id=7ec999ba49","beamer_address":"us8@inbound.mailchimp.com","visibility":"pub","stats":{"member_count":24,"unsubscribe_count":0,"cleaned_count":0,"member_count_since_send":27,"unsubscribe_count_since_send":0,"cleaned_count_since_send":0,"campaign_count":0,"grouping_count":0,"group_count":0,"merge_var_count":1,"avg_sub_rate":0,"avg_unsub_rate":0,"target_sub_rate":0,"open_rate":0,"click_rate":0,"date_last_campaign":null},"modules":[]}],"errors":[]}'
+    http_version:
+  recorded_at: Mon, 06 Jul 2015 05:36:27 GMT
+- request:
+    method: post
+    uri: https://us8.api.mailchimp.com/2.0/lists/subscribe
+    body:
+      encoding: UTF-8
+      string: '{"apikey":"","id":"7ec999ba49","email":{"email":"blanca.lehner@klockodoyle.net"},"merge_vars":{"DNAME":"Alek
+        Romaguera"},"double_optin":false,"update_existing":true}'
+    headers: {}
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '80'
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Mon, 06 Jul 2015 05:36:28 GMT
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - _AVESTA_ENVIRONMENT=prod; path=/
+    body:
+      encoding: UTF-8
+      string: '{"email":"blanca.lehner@klockodoyle.net","euid":"57ee2f5e2a","leid":"266178321"}'
+    http_version:
+  recorded_at: Mon, 06 Jul 2015 05:36:28 GMT
+recorded_with: VCR 2.9.3

--- a/vcr/models/user_spec/mailing_list.yml
+++ b/vcr/models/user_spec/mailing_list.yml
@@ -1,0 +1,69 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://us8.api.mailchimp.com/2.0/lists/list
+    body:
+      encoding: UTF-8
+      string: '{"apikey":"","filters":{"list_name":"OpenFarm
+        Subscribers"}}'
+    headers: {}
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '978'
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Mon, 06 Jul 2015 05:36:26 GMT
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - _AVESTA_ENVIRONMENT=prod; path=/
+    body:
+      encoding: UTF-8
+      string: '{"total":1,"data":[{"id":"8b8c94b1c5","web_id":435541,"name":"OpenFarm
+        Subscribers","date_created":"2014-07-17 18:58:16","email_type_option":false,"use_awesomebar":true,"default_from_name":"OpenFarm","default_from_email":"rory@openfarm.cc","default_subject":"","default_language":"en","list_rating":3.5,"subscribe_url_short":"http:\/\/eepurl.com\/bbQeJ5","subscribe_url_long":"http:\/\/openfarm.us8.list-manage1.com\/subscribe?u=d41f97f612d606f032a884227&id=8b8c94b1c5","beamer_address":"@inbound.mailchimp.com","visibility":"pub","stats":{"member_count":2176,"unsubscribe_count":53,"cleaned_count":6,"member_count_since_send":183,"unsubscribe_count_since_send":9,"cleaned_count_since_send":1,"campaign_count":11,"grouping_count":1,"group_count":1,"merge_var_count":2,"avg_sub_rate":79,"avg_unsub_rate":4,"target_sub_rate":4,"open_rate":48.929688786432,"click_rate":11.968348170129,"date_last_campaign":"2015-04-05
+        15:00:48"},"modules":[]}],"errors":[]}'
+    http_version:
+  recorded_at: Mon, 06 Jul 2015 05:36:26 GMT
+- request:
+    method: post
+    uri: https://us8.api.mailchimp.com/2.0/lists/subscribe
+    body:
+      encoding: UTF-8
+      string: '{"apikey":"","id":"8b8c94b1c5","email":{"email":"halle@cummings.com"},"merge_vars":{"DNAME":"Kenya
+        Bergnaum"},"double_optin":false,"update_existing":true}'
+    headers: {}
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '69'
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Mon, 06 Jul 2015 05:36:26 GMT
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - _AVESTA_ENVIRONMENT=prod; path=/
+    body:
+      encoding: UTF-8
+      string: '{"email":"halle@cummings.com","euid":"8db461ac88","leid":"266178317"}'
+    http_version:
+  recorded_at: Mon, 06 Jul 2015 05:36:27 GMT
+recorded_with: VCR 2.9.3


### PR DESCRIPTION
# What's Changed
* The big change here is the crop data structure. It includes `genus`, `species`, and `cultivar_name`. There's also a commented-out version of the varieties & parents. Am still figuring out that structure. To do with #641.
* Brought test coverage up to 100% by adding a VCR for the request to Mailchimp. This isn't ideal, but at least it tests that the method gets called. 
* Close #644. Somehow that was `self` instead of `list`. 