### PR TITLE
Add config.vm.box_url so Vagrant knows where to download Ubuntu from.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,6 +6,7 @@ VAGRANTFILE_API_VERSION = "2"
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # Use Ubuntu 14.04 Trusty Tahr 64-bit as our operating system
   config.vm.box = "ubuntu/trusty64"
+  config.vm.box_url = "http://cloud-images.ubuntu.com/vagrant/trusty/current/trusty-server-cloudimg-amd64-vagrant-disk1.box"
 
   # Configurate the virtual machine to use 2GB of RAM
   config.vm.provider :virtualbox do |vb|


### PR DESCRIPTION
This is just a small suggestion commit - I cloned the repo and ran `vagrant up`, but hit the following error:

    $ vagrant up
    Bringing machine 'default' up with 'virtualbox' provider...
    There are errors in the configuration of this machine. Please fix
    the following errors and try again:
    
    vm:
    * The box 'ubuntu/trusty64' could not be found.

This is because my computer was unfamiliar with a box titled "ubuntu/trusty64" (I do have a box called simply "trusty64", but it didn't match up so was not used).

There are two solutions to this. One is to add an additional manual step to the setup, instructing the user how to tell Vagrant where to find the "ubuntu/trusty64" box.  (See http://serverfault.com/questions/679190/where-to-download-vagrant-boxes)

OR:

With this commit, the URL of the box is included in the Vagrantfile itself. So the extra step is not necessary, and everything happens automatically with `vagrant up`