### PR TITLE
Fix Issue#628 Made Changes Suggested By Hound (A Clean-er Code)

### DIFF
--- a/spec/features/confirmations_controller_spec.rb
+++ b/spec/features/confirmations_controller_spec.rb
@@ -4,38 +4,37 @@ class User
   attr_reader :raw_confirmation_token
 end
 
-RSpec.describe ConfirmationsController, :type => :controller do
-
+RSpec.describe ConfirmationsController, type: :controller do
   def visit_user_confirmation_with_token(confirmation_token)
     visit user_confirmation_path(confirmation_token: confirmation_token)
   end
 
-  context "when confirmation token is valid" do
-    context "when user filled the required settings" do
+  context 'when confirmation token is valid' do
+    context 'when user filled the required settings' do
       let(:user) { FactoryGirl.create(:user, :with_user_setting) }
-      it "redirects to member profile page" do
+      it 'redirects to member profile page' do
         user.send_confirmation_instructions
         visit_user_confirmation_with_token(user.raw_confirmation_token)
         expect(response.status).to eq(200)
-        expect(response).to render_template("users/show")
+        expect(response).to render_template('users/show')
       end
     end
-    context "when user has not filled the required settings" do
+    context 'when user has not filled the required settings' do
       let(:user) { FactoryGirl.create(:user) }
-      it "redirects to user details page" do
+      it 'redirects to user details page' do
         user.send_confirmation_instructions
         visit_user_confirmation_with_token(user.raw_confirmation_token)
         expect(response.status).to eq(200)
-        expect(response).to render_template("users/finish")
+        expect(response).to render_template('users/finish')
       end
     end
   end
 
-  context "when confirmation token is invalid" do
-    it "renders error page" do
+  context 'when confirmation token is invalid' do
+    it 'renders error page' do
       visit_user_confirmation_with_token("random_string")
       expect(response.status).to eq(200)
-      expect(response).to render_template("devise/confirmations/new")
+      expect(response).to render_template('devise/confirmations/new')
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -16,7 +16,7 @@ describe User do
     expect(user.has_filled_required_settings?).to be true
   end
 
-  context "should be invalid to not fill in required settings" do
+  context 'should be invalid to not fill in required settings' do
     it 'should be invalid to have either of location or units missing' do
       user = FactoryGirl.create(:user)
       expect(user.has_filled_required_settings?).to be false


### PR DESCRIPTION
Removed double quotes from confirmations_controller_spec.rb, and shifted to Ruby 1.9 Hash Syntax