### PR TITLE
Issue#750 Fixed

### DIFF
--- a/app/assets/javascripts/crops/edit.js
+++ b/app/assets/javascripts/crops/edit.js
@@ -60,7 +60,7 @@ openFarmApp.controller('cropCtrl', ['$scope', '$http', 'cropService',
         cropService.createCropWithPromise(crop)
           .then(function(crop) {
             // $scope.crop.sending = false;
-            window.location.href = '/crops/' + $scope.crop.id + '/';
+            window.location.href = '/crops/' + crop.id + '/';
           })
       } else {
         cropService.updateCrop($scope.crop.id,


### PR DESCRIPTION
The older code was referring to $scope.crop object which only existed for updateCrop(). createCropWithPromise() uses the object entered by the user called 'crop' which is not $scope.