### PR TITLE
Fixed #Issue786: Forcing square images in crop_search results

### DIFF
--- a/app/assets/javascripts/templates/_crop_search.html
+++ b/app/assets/javascripts/templates/_crop_search.html
@@ -29,7 +29,7 @@
 
 <script type="text/ng-template" id="custom.html">
   <a class="crop-list-item" tabindex="-1">
-      <img ng-src="{{match.model.main_image_path}}" height="50px" width="50px"/>
+      <img class="crop-img" ng-src="{{match.model.main_image_path}}" height="50px" width="50px"/>
       <span class="crop-name" bind-html-unsafe="match.model.name | typeaheadHighlight:query"></span>
       <span class="guide-count" bind-html-unsafe="match.model.guides_count + ' guides'"></span>
   </a>

--- a/app/assets/stylesheets/styles/components/pages/_home.scss
+++ b/app/assets/stylesheets/styles/components/pages/_home.scss
@@ -188,3 +188,8 @@ video { display: block; }
 .guide-count {
   padding-right: 1em;
 }
+
+.crop-img {
+  height: 50px;
+  object-fit: cover;
+}


### PR DESCRIPTION
* Added image CSS to `pages/_home.scss` for forcing square images in the search crop results.

@roryaronson @simonv3 I wasn't exactly sure how to test this without a PR, but I implemented the CSS in the element inspector (both staging and production) before adding it so I'm guessing it should fix #786 