### PR TITLE
Enhancing lightbox directive for generic directive calls

### DIFF
--- a/app/assets/javascripts/angular-libs/angular.of.directives.lightbox-modal.js
+++ b/app/assets/javascripts/angular-libs/angular.of.directives.lightbox-modal.js
@@ -3,17 +3,18 @@ openFarmApp.directive('ofLightboxModal', ['$http', '$modal', 'stageService',
     return {
       restrict: 'A',
       scope: {
-        picture: '=ofLightboxModal',
-        description: '='
+        thumbnailUrl: '@',
+        displayUrl: '@',
+        description: '@?'
       },
       controller: ['$scope',
         function ($scope) {
           $scope.open = function () {
             var modalInstance = $modal.open({
-              template: '<img ng-src="{{picture.image_url}}"/><span ng-bind="description"></span>',
-              controller: ['$scope', '$modalInstance', 'picture', 'description',
-              function ($scope, $modalInstance, picture, description) {
-                $scope.picture = picture
+              template: '<img ng-src="{{displayUrl}}"/><span ng-bind="description"></span>',
+              controller: ['$scope', '$modalInstance', 'displayUrl', 'description',
+              function ($scope, $modalInstance, displayUrl, description) {
+                $scope.displayUrl = displayUrl
                 $scope.description = description
 
                 $scope.reposition = function () {
@@ -30,8 +31,8 @@ openFarmApp.directive('ofLightboxModal', ['$http', '$modal', 'stageService',
 
               }],
               resolve: {
-                picture: function () {
-                  return $scope.picture
+                displayUrl: function () {
+                  return $scope.displayUrl
                 },
                 description: function () {
                   return $scope.description
@@ -47,7 +48,7 @@ openFarmApp.directive('ofLightboxModal', ['$http', '$modal', 'stageService',
           }
         }
       ],
-      template: "<img class='lightbox-thumbnail' ng-src='{{picture.medium_url}}' ng-click='open()'/>"
+      template: "<img class='lightbox-thumbnail' ng-src='{{thumbnailUrl}}' ng-click='open()'/>"
     }
   }
 ])

--- a/app/assets/javascripts/angular-libs/guides/show/guides.show.stage-action.template.html
+++ b/app/assets/javascripts/angular-libs/guides/show/guides.show.stage-action.template.html
@@ -12,7 +12,9 @@
   </div>
   <span ng-repeat="picture in action.pictures"
     ng-hide="editingStage">
-    <a of-lightbox-modal="picture" description="$parent.name"></a>
+    <a of-lightbox-modal thumbnail-url="{{picture.medium_url}}"
+      display-url="{{picture.image_url}}" description="$parent.name">
+    </a>
   </span>
   <div class="upload-stage-picture"
       s3-upload

--- a/app/assets/javascripts/angular-libs/guides/show/guides.show.stage.template.html
+++ b/app/assets/javascripts/angular-libs/guides/show/guides.show.stage.template.html
@@ -22,8 +22,9 @@
     ng-class="{ 'small-3': stage.pictures.length === 0 }">
     <span ng-repeat="pic in stage.pictures"
       ng-if="!editingStage">
-      <a of-lightbox-modal="pic"
-         description="$parent.name"></a>
+      <a of-lightbox-modal thumbnail-url="{{pic.medium_url}}"
+        display-url="{{pic.image_url}}" description="$parent.name">
+      </a>
     </span>
     <span ng-if="stage.pictures.length === 0"
       class="stage-default-picture stage-option {{ stage.name | lowercase }}">


### PR DESCRIPTION
* Removed hardcoded instances of `picture.image_url` and `picture.medium_url` from the `ofLightBox` directive.
* Added `thumbnailUrl` and `displayUrl` which serve as final urls to be added into the templates for the Light Box directive
This is a generic change in code so that calls to this directive can be made without changing js code.