### PR TITLE
Fix issue#765: Logged out users can't mark favorite guides

### DIFF
--- a/app/assets/javascripts/angular-libs/angular.openfarm.js
+++ b/app/assets/javascripts/angular-libs/angular.openfarm.js
@@ -27,6 +27,9 @@ openFarmModule.factory('alertsService', ['$rootScope',
         if (['200','201','202'].indexOf(code) !== -1) {
           msg_type = 'success'
         }
+        if (code % 400 > 0 && code % 400 < 100) {
+          msg_type = 'alert'
+        }
 
         console.log(response)
         var msg = response.map(function(obj){

--- a/app/assets/javascripts/angular-libs/angular.openfarm.js
+++ b/app/assets/javascripts/angular-libs/angular.openfarm.js
@@ -27,7 +27,7 @@ openFarmModule.factory('alertsService', ['$rootScope',
         if (['200','201','202'].indexOf(code) !== -1) {
           msg_type = 'success'
         }
-        if (code % 400 > 0 && code % 400 < 100) {
+        if (code >= 400 && code < 500) {
           msg_type = 'alert'
         }
 

--- a/app/assets/javascripts/guides/show.js
+++ b/app/assets/javascripts/guides/show.js
@@ -1,5 +1,6 @@
 openFarmApp.controller('showGuideCtrl', ['$scope', '$http', 'guideService', '$q',
     'userService', 'gardenService', 'cropService', 'stageService', 'defaultService',
+    'alertsService',
   function showGuideCtrl($scope,
                          $http,
                          guideService,
@@ -8,7 +9,8 @@ openFarmApp.controller('showGuideCtrl', ['$scope', '$http', 'guideService', '$q'
                          gardenService,
                          cropService,
                          stageService,
-                         defaultService) {
+                         defaultService,
+                         alertsService) {
     $scope.guideId = getIDFromURL('guides') || GUIDE_ID;
     $scope.userId = USER_ID || undefined;
     $scope.gardenCrop = {};
@@ -219,34 +221,38 @@ openFarmApp.controller('showGuideCtrl', ['$scope', '$http', 'guideService', '$q'
         $scope.guide.crop = data[1];
       });
     }
-
     function favoriteGuide (guideId) {
-      $scope.updatingFavoritedGuides = true;
-      var favorited_guide_ids = $scope.currentUser.favorited_guides.map(function (g) { return g.id; }) || [];
-      var index = favorited_guide_ids.indexOf(guideId);
-      if (index === -1) {
-        favorited_guide_ids.push(guideId);
-      } else {
-        favorited_guide_ids.splice(index, 1);
+      if ($scope.currentUser == null){
+        alertsService.pushToAlerts(["You need to log in to mark your favorite"], 401);
       }
+      else{
+        $scope.updatingFavoritedGuides = true;
+        var favorited_guide_ids = $scope.currentUser.favorited_guides.map(function (g) { return g.id; }) || [];
+        var index = favorited_guide_ids.indexOf(guideId);
+        if (index === -1) {
+          favorited_guide_ids.push(guideId);
+        } else {
+          favorited_guide_ids.splice(index, 1);
+        }
 
-      var params = {
-        'favorited_guide_ids': favorited_guide_ids
-      };
+        var params = {
+          'favorited_guide_ids': favorited_guide_ids
+        };
 
-      if ($scope.currentUser.user_setting.picture &&
-          !$scope.currentUser.user_setting.picture.deleted) {
-        params.featured_image = $scope.currentUser.user_setting.picture.image_url || null;
-      } else {
-        params.featured_image = null;
+        if ($scope.currentUser.user_setting.picture &&
+            !$scope.currentUser.user_setting.picture.deleted) {
+          params.featured_image = $scope.currentUser.user_setting.picture.image_url || null;
+        } else {
+          params.featured_image = null;
+        }
+
+        userService.updateUserWithPromise($scope.currentUser.id, params).then(function (user) {
+          $scope.updatingFavoritedGuides = false;
+          $scope.setCurrentUser(true, user);
+        }).catch(function (response, code) {
+
+        });
       }
-
-      userService.updateUserWithPromise($scope.currentUser.id, params).then(function (user) {
-        $scope.updatingFavoritedGuides = false;
-        $scope.setCurrentUser(true, user);
-      }).catch(function (response, code) {
-
-      });
     }
 
     guideService.getGuideWithPromise($scope.guideId)

--- a/app/assets/javascripts/guides/show.js
+++ b/app/assets/javascripts/guides/show.js
@@ -222,7 +222,7 @@ openFarmApp.controller('showGuideCtrl', ['$scope', '$http', 'guideService', '$q'
       });
     }
     function favoriteGuide (guideId) {
-      if ($scope.currentUser === undefined){
+      if (!$scope.currentUser){
         alertsService.pushToAlerts(["You need to log in to mark your favorite"], 401);
       }
       else{

--- a/app/assets/javascripts/guides/show.js
+++ b/app/assets/javascripts/guides/show.js
@@ -222,7 +222,7 @@ openFarmApp.controller('showGuideCtrl', ['$scope', '$http', 'guideService', '$q'
       });
     }
     function favoriteGuide (guideId) {
-      if ($scope.currentUser == null){
+      if ($scope.currentUser === undefined){
         alertsService.pushToAlerts(["You need to log in to mark your favorite"], 401);
       }
       else{


### PR DESCRIPTION
I added the following code:
* An `if` condition in `guides/show.js` to check if the user is logged in.
* Made some changes to `alertsService` to display an `alert` `msg_type` for appropriate requests.

This PR fixes #765 