### PR TITLE
Fix typos in environment warning

### DIFF
--- a/config/environment.rb
+++ b/config/environment.rb
@@ -1,12 +1,14 @@
 if File.exists?('config/app_environment_variables.rb')
   load 'config/app_environment_variables.rb'
 else
-  warning = 'You might still need to set your ENV variables inside of'\
-            'config/app_environment_variables.rb Take a look at'\
-            'config/app_environment_variables.rb.example. Raise an issue on'\
-            'OpenFarms GitHub page if you still cant get it working. If you'\
-            'are seeing this from within your CI or production server, you can'\
-            'ignore this message. Make sure you set your ENV vars, though.'
+  warning = [
+    'You might still need to set your ENV variables inside of'
+    'config/app_environment_variables.rb Take a look at'
+    'config/app_environment_variables.rb.example. Raise an issue on'
+    'OpenFarms GitHub page if you still cant get it working. If you'
+    'are seeing this from within your CI or production server, you can'
+    'ignore this message. Make sure you set your ENV vars, though.'
+  ].join(' ')
   warn warning
 end
 

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -2,11 +2,11 @@ if File.exists?('config/app_environment_variables.rb')
   load 'config/app_environment_variables.rb'
 else
   warning = [
-    'You might still need to set your ENV variables inside of'
-    'config/app_environment_variables.rb Take a look at'
-    'config/app_environment_variables.rb.example. Raise an issue on'
-    'OpenFarms GitHub page if you still cant get it working. If you'
-    'are seeing this from within your CI or production server, you can'
+    'You might still need to set your ENV variables inside of',
+    'config/app_environment_variables.rb Take a look at',
+    'config/app_environment_variables.rb.example. Raise an issue on',
+    'OpenFarms GitHub page if you still cant get it working. If you',
+    'are seeing this from within your CI or production server, you can',
     'ignore this message. Make sure you set your ENV vars, though.'
   ].join(' ')
   warn warning


### PR DESCRIPTION
On travis; we see:


You might still need to set your ENV variables inside ofconfig/app_environment_variables.rb Take a look atconfig/app_environment_variables.rb.example. Raise an issue onOpenFarms GitHub page if you still cant get it working. If youare seeing this from within your CI or production server, you canignore this message. Make sure you set your ENV vars, though.


Which reads a bit funny