### PR TITLE
Client side validation of crop add/edit form

### DIFF
--- a/app/assets/stylesheets/main.scss
+++ b/app/assets/stylesheets/main.scss
@@ -8,6 +8,7 @@
 @import "styles/ui/icons";
 @import "styles/ui/compatibility_circle";
 @import "styles/ui/badges-list";
+@import "styles/ui/forms";
 @import "styles/ui/inputs/**/*";
 
 @import "styles/components/alerts",

--- a/app/assets/stylesheets/styles/ui/_forms.scss
+++ b/app/assets/stylesheets/styles/ui/_forms.scss
@@ -1,4 +1,4 @@
 .form-required {
-  color: red;
-  font-size: 0.875rem;
+  color: $of-red;
+  font-size: .875rem;
 }

--- a/app/assets/stylesheets/styles/ui/_forms.scss
+++ b/app/assets/stylesheets/styles/ui/_forms.scss
@@ -1,4 +1,4 @@
 .form-required {
-  color: $of-red;
+  color: $alert-color;
   font-size: .875rem;
 }

--- a/app/assets/stylesheets/styles/ui/_forms.scss
+++ b/app/assets/stylesheets/styles/ui/_forms.scss
@@ -1,0 +1,4 @@
+.form-required {
+  color: red;
+  font-size: 0.875rem;
+}

--- a/app/assets/stylesheets/styles/ui/inputs/inputs.scss
+++ b/app/assets/stylesheets/styles/ui/inputs/inputs.scss
@@ -17,5 +17,5 @@ textarea {
 }
 
 input.ng-invalid {
-  border: 1px solid red;
+  border: 1px solid $of-red;
 }

--- a/app/assets/stylesheets/styles/ui/inputs/inputs.scss
+++ b/app/assets/stylesheets/styles/ui/inputs/inputs.scss
@@ -15,3 +15,7 @@ input[type="color"],
 textarea {
   border-radius: $global-radius;
 }
+
+input.ng-invalid {
+  border: 1px solid red;
+}

--- a/app/assets/stylesheets/styles/ui/inputs/inputs.scss
+++ b/app/assets/stylesheets/styles/ui/inputs/inputs.scss
@@ -17,5 +17,5 @@ textarea {
 }
 
 input.ng-invalid {
-  border: 1px solid $of-red;
+  border: 1px solid $alert-color;
 }

--- a/app/views/crops/_crop_form.html.erb
+++ b/app/views/crops/_crop_form.html.erb
@@ -13,18 +13,20 @@
           Add a new crop
         <% end %>
       </h1>
+      <p><span class="form-required">* Required</span></p>
     </div>
   </div>
-  <form>
+  <form name="cropForm">
     <div class="row">
       <div class="columns small-4 medium-4">
-        <label class="right" for="crop_name">OpenFarm Crop Name</label>
+        <label class="right" for="crop_name">OpenFarm Crop Name <span class="form-required">*</span></label>
       </div>
       <div class="columns small-8 medium-8">
         <input data-ng-model="crop.name"
                id="crop_name"
                name="crop[name]"
-               type="text"/>
+               type="text"
+               required/>
       </div>
     </div>
 
@@ -210,7 +212,7 @@
             name="commit"
             value="<%= t('crops.edit.save_crop') %>"
             data-disable-with="Saving..."
-            ng-disabled="crop.sending"
+            ng-disabled="crop.sending || cropForm.$invalid""
             ng-click="submitForm()"/>
         </span>
       </div>

--- a/app/views/crops/_crop_form.html.erb
+++ b/app/views/crops/_crop_form.html.erb
@@ -126,7 +126,7 @@
             <input data-ng-model="crop.spread"
                    id="crop_spread"
                    name="crop[spread]"
-                  type="text"/>
+                  type="number"/>
           </div>
           <div class="columns small-2">
             <span class="postfix">cm</small>


### PR DESCRIPTION
Resolves #806.

By adding the `required` attribute to any required fields (such as crop name), the form will now make sure the required fields are present and if not, will disable the submit button. 

It will also be disabled if any of the fields have the `ng-invalid` class applied to it, which happens when the number inputs are invalid. The invalid input forms will then have a red border applied to it to alert the user of the reason why they can't submit the form, but we probably want to have some kind of form messaging system that makes it clearer.

<img width="876" alt="screenshot 2016-10-04 16 00 49" src="https://cloud.githubusercontent.com/assets/1063758/19095690/1c9e2dcc-8a4c-11e6-83d0-0a718a89df4e.png">

<img width="759" alt="screenshot 2016-10-04 16 00 42" src="https://cloud.githubusercontent.com/assets/1063758/19095697/2311bf20-8a4c-11e6-842b-6c6d320d82f1.png">

