### PR TITLE
[Fix #836] Add installation of vagrant-triggers to Vagrantfile

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,6 +3,19 @@
 
 VAGRANTFILE_API_VERSION = "2"
 
+# See: http://stackoverflow.com/a/28801317
+required_plugins = %w(vagrant-triggers)
+
+plugins_to_install = required_plugins.select { |plugin| !Vagrant.has_plugin?(plugin) }
+if plugins_to_install.any?
+  puts "Installing plugins: #{plugins_to_install.join(' ')}"
+  if system "vagrant plugin install #{plugins_to_install.join(' ')}"
+    exec "vagrant #{ARGV.join(' ')}"
+  else
+    abort "Installation of one or more plugins has failed. Aborting."
+  end
+end
+
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # Use Ubuntu 14.04 Trusty Tahr 64-bit as our operating system
   config.vm.box = "ubuntu/trusty64"


### PR DESCRIPTION
Fix #836 
I'm not a Vagrant expert, but I found a simple fix [here](http://stackoverflow.com/a/28801317) that seems to do the job. It installs the plugin before the box provisioning.

```shell
$ vagrant up
Installing plugins: vagrant-triggers
Installing the 'vagrant-triggers' plugin. This can take a few minutes...
Installed the plugin 'vagrant-triggers (0.5.3)'!
Bringing machine 'default' up with 'virtualbox' provider...
...
```

I didn't amend the README since it should happen automatically.