### PR TITLE
https://github.com/openfarmcc/OpenFarm/issues/850

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -16,7 +16,7 @@ echo "OKAY - GOING TO INSTALL OUR OWN THINGS NOW"
 
 echo "--- INSTALLING RVM ---"
 
-gpg --keyserver hkp://keys.gnupg.net --recv-keys D39DC0E3
+gpg --keyserver hkp://pool.sks-keyservers.net:80 --recv-keys D39DC0E3
 
 curl -sSL https://get.rvm.io | bash -s stable --quiet-curl --ruby=2.2.5
 

--- a/scripts/up.sh
+++ b/scripts/up.sh
@@ -11,9 +11,11 @@ rvm reload
 
 ELASTICSEARCH_URL='http://127.0.0.1:9201'
 
+sleep 10
+
 cd /vagrant
 
 # bundle install
-rails s
+rails s -d -b 0.0.0.0 
 
 echo "--- SERVER STARTED ---"


### PR DESCRIPTION
Changes:

- Replaced keys.gnupg.net alias address in bootstrap.sh for pool.sks-keyservers.net (as suggested on issue: https://github.com/rvm/rvm/issues/3110) as this solves the time out problem, also forced it to run on port 80

- Added 10 second sleep between elastic search and rails startup 

- Added detach to rails server startup to prevent Vagrant VMs to hang and not return the command prompt

- Add 0.0.0.0 interface on rails startup to be able to access from host (discussed on: http://stackoverflow.com/questions/28668436/how-to-change-the-default-binding-ip-of-rails-4-2-development-server)

