### PR TITLE
Increase logo size and make it clickable everywhere

### DIFF
--- a/app/assets/stylesheets/styles/components/_nav.scss
+++ b/app/assets/stylesheets/styles/components/_nav.scss
@@ -1,11 +1,12 @@
 .top-bar {
 
-  .logo {
-    margin: 10px;
-  }
-
+  height: 71px;
   z-index: 9999;
   box-shadow: 0 0 4px rgba(0, 0, 0, .5);
+
+  .logo {
+    margin: 20px 10px 10px 30px;
+  }
 
   input[type='submit']{
     padding: 0;
@@ -19,6 +20,7 @@
   .header-search{
     max-width: 400px;
     width: 47%;
+    margin-top: 17.5px;
   }
 
   @media #{$small-only}{
@@ -42,6 +44,11 @@
     }
   }
 
+  // nudge the right menu down and over
+  ul.right {
+    margin-top: 13px;
+  }
+
   // Special home nav style
   // Confused by the backwards ampersand?
   // http://thesassway.com/intermediate/referencing-parent-selectors-using-ampersand
@@ -53,6 +60,14 @@
     right: 0;
     background-color: transparent !important;
     box-shadow: none;
+
+    .name a {
+    background: transparent !important;
+      
+      &:hover {
+          background-color: transparent !important;
+      }   
+    }
 
     li {
       background: transparent !important;
@@ -82,9 +97,5 @@
       // }
     }
 
-    // nudge the right menu down and over
-    ul.right {
-      margin-top: 10px;
-    }
   }
 }

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -15,17 +15,17 @@
   <head>
     <meta charset="utf-8" />
 
-	<%= render 'meta/global' %>
-	<%= render 'meta/page' %>
-	<%= render 'meta/social_network' %>
+  <%= render 'meta/global' %>
+  <%= render 'meta/page' %>
+  <%= render 'meta/social_network' %>
 
     <!-- Uncomment to make IE8 render like IE7 -->
     <!-- <meta http-equiv="X-UA-Compatible" content="IE=7" /> -->
 
-  	<!-- Set the viewport width to device width for mobile -->
-  	<meta name="viewport" content="width=device-width, initial-scale=0.82, minimum-scale=0.10, maximum-scale=10.0, user-scalable=yes" />
+    <!-- Set the viewport width to device width for mobile -->
+    <meta name="viewport" content="width=device-width, initial-scale=0.82, minimum-scale=0.10, maximum-scale=10.0, user-scalable=yes" />
 
-  	<title>
+    <title>
         <%= t('application.site_title') %>
         <%= content_for?(:title) ? yield(:title) : ' - ' + t('application.site_byline') %>
     </title>
@@ -46,16 +46,9 @@
       <nav class="top-bar" data-topbar role="navigation">
           <ul class="title-area">
               <li class="name">
-                <% if current_page?(root_path) or current_page?("/") %>
                   <h1>
-                    <!-- The logo on the home page is not clickable. The logo on the other pages links to the home page. -->
-                    <img class="logo" src="<%= image_path 'openfarm_logo_small.png' %>" width="110px">                    
+                    <%= link_to(image_tag('openfarm_logo_small.png', :width => '210px', :alt => 'Open Farm', :class => 'logo'), root_path) %>
                   </h1>
-                <% else %>
-                  <h1>
-                    <%= link_to(image_tag('openfarm_logo_small.png', :width => '110px', :alt => 'Open Farm'), root_path) %>
-                  </h1>
-                <% end %>
               </li>
               <li class="toggle-topbar">
                   <a href="#"><span>Menu</span></a>


### PR DESCRIPTION
re this conversation: https://github.com/openfarmcc/OpenFarm/pull/860

Make the logo clickable from everywhere it is displayed. Now, the logo refreshes the home page when clicked from the home page (and still redirects to the home page when clicked from elsewhere). Increase the logo size to 210x41 and add margin: 20px 10px 10px 30px. Increase the top bar height to accomodate the taller logo. Vertically align the other elements in the re-sized top bar so that the bottom of each element lines up with the bottom of the text in the logo.