### PR TITLE
Updated ID of favorite button to not clash with print button

### DIFF
--- a/app/views/guides/show/_guide_controllers.html.erb
+++ b/app/views/guides/show/_guide_controllers.html.erb
@@ -13,7 +13,7 @@
     <%= link_to(icon('trash') + ' ' + t('.delete_guide'), guide_path(@guide), method: 'delete', class: 'button tiny secondary edit-link', data: {confirm: "Are you sure?"}) %>
   <% end %>
   <a type="button" id="print" class="button tiny secondary edit-link" onclick="print()"><%= icon('print') + ' ' + t('.print_guide') %></a>
-  <a type="button" id="print" class="button tiny secondary edit-link" ng-class="{ favorite : inFavorites }" ng-click="favoriteGuide(guide.id)">
+  <a type="button" id="favorite" class="button tiny secondary edit-link" ng-class="{ favorite : inFavorites }" ng-click="favoriteGuide(guide.id)">
     <i class="fa fa-star"
       ng-class="{'fa-spin':updatingFavoritedGuides}"></i>
     <%= t('.favorite') %>


### PR DESCRIPTION
Element IDs should be unique.

Another option would be to remove both of the similar IDs as I can't see them being used anywhere.