### PR TITLE
Added missing setup step to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ $ cd OpenFarm
 $ bundle install
 $ rake db:setup
 $ echo "ENV['SECRET_KEY_BASE'] = '$(rake secret)'" >> config/app_environment_variables.rb
+$ echo "ENV['GOOGLE_MAPS_API_KEY'] = ''" >> config/app_environment_variables.rb # or get an actual API key at https://console.developers.google.com/flows/enableapi?apiid=maps_backend&keyType=CLIENT_SIDE&reusekey=true&pli=1
 $ rails s
 ```
 


### PR DESCRIPTION
Added Google maps API key setup info to README - you get a runtime error if it's not set.

Alternatively, we could add a new initialiser at config/initializers/dev.rb with something like:

```
unless Rails.env.production?
  ENV['SECRET_KEY_BASE'] = '<something>'
  ENV['GOOGLE_MAPS_API_KEY'] = ''
end
```

which would remove the requirement for this setup step and the SECRET_KEY_BASE step