### PR TITLE
Updated devise config

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -1,14 +1,4 @@
 Devise.setup do |config|
-  # Devise is really peculiar about how it is given its SECRET_KEY_BASE
-  # TODO: Fix this mess.
-  # :nocov:
-  if ['production', 'staging'].include?(Rails.env)
-    devise_acts_weird = ENV['SECRET_KEY_BASE']
-  else
-    devise_acts_weird = ENV['SECRET_KEY_BASE']  || `rake secret`
-  end
-  # :nocov:
-  config.secret_key = devise_acts_weird
   config.mailer_sender = 'team@openfarm.cc'
   require 'devise/orm/mongoid'
   config.case_insensitive_keys = [ :email ]


### PR DESCRIPTION
Devise automatically sets it's secret_key from secret_key_base by default: https://github.com/plataformatec/devise/blob/v3.2.3/CHANGELOG.md#323