### PR TITLE
Bring down moment to version known to work

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -57,7 +57,7 @@ source 'https://rails-assets.org' do
   gem 'rails-assets-angular-local-storage', '~> 0.2.3'
   gem 'rails-assets-angular-typeahead', '~> 0.3.1'
   gem 'rails-assets-ng-tags-input', '~>2.3.0'
-  gem 'rails-assets-moment', '~>2.17.1'
+  gem 'rails-assets-moment', '~>2.8.3'
   gem 'rails-assets-showdown', '~>0.5.4'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -336,7 +336,7 @@ GEM
     rails-assets-jquery (2.2.4)
     rails-assets-jquery-ui (1.11.4)
       rails-assets-jquery (>= 1.6)
-    rails-assets-moment (2.17.1)
+    rails-assets-moment (2.8.4)
     rails-assets-ng-tags-input (2.3.0)
       rails-assets-angular (>= 1.2.1)
     rails-assets-showdown (0.5.4)
@@ -530,7 +530,7 @@ DEPENDENCIES
   rails-assets-angular-ui-sortable (~> 0.13.4)!
   rails-assets-jquery (~> 2.2.1)!
   rails-assets-jquery-ui (~> 1.11.4)!
-  rails-assets-moment (~> 2.17.1)!
+  rails-assets-moment (~> 2.8.3)!
   rails-assets-ng-tags-input (~> 2.3.0)!
   rails-assets-showdown (~> 0.5.4)!
   rails_12factor


### PR DESCRIPTION
Moment at 2.17.1 broke the Heroku build. Probably because it's es6 and we don't have a compiler for it. 