### PR TITLE
Add created_at and updated_at dates to all models

### DIFF
--- a/app/models/crop.rb
+++ b/app/models/crop.rb
@@ -5,6 +5,7 @@ class Crop
   include Mongoid::Timestamps
   include Mongoid::Slug
   include Mongoid::Taggable
+
   searchkick
 
   is_impressionable counter_cache: true,

--- a/app/models/crop_data_source.rb
+++ b/app/models/crop_data_source.rb
@@ -1,5 +1,6 @@
 class CropDataSource
   include Mongoid::Document
+  include Mongoid::Timestamps
 
   has_many :crops
 

--- a/app/models/crops_tag_index.rb
+++ b/app/models/crops_tag_index.rb
@@ -1,5 +1,7 @@
 class CropsTagIndex
   include Mongoid::Document
+  include Mongoid::Timestamps
+
   store_in collection: 'crops_tags_index'
 
   field :value, type: Integer

--- a/app/models/detail_option.rb
+++ b/app/models/detail_option.rb
@@ -6,6 +6,8 @@
 
 class DetailOption
   include Mongoid::Document
+  include Mongoid::Timestamps
+
   field :name, type: String
   field :description, type: String
   field :help, type: String

--- a/app/models/garden.rb
+++ b/app/models/garden.rb
@@ -1,5 +1,6 @@
 class Garden
   include Mongoid::Document
+  include Mongoid::Timestamps
 
   belongs_to :user
   validates_presence_of :user

--- a/app/models/garden_crop.rb
+++ b/app/models/garden_crop.rb
@@ -1,6 +1,8 @@
 class GardenCrop
   include Mongoid::Document
   include Mongoid::History::Trackable
+  include Mongoid::Timestamps
+
   embedded_in :garden
   embeds_one :guide, class_name: 'Guide', inverse_of: nil
   embeds_one :crop, class_name: 'Crop', inverse_of: nil

--- a/app/models/guide.rb
+++ b/app/models/guide.rb
@@ -2,6 +2,8 @@ class Guide
   include Mongoid::Document
   include Mongoid::Paperclip
   include Mongoid::Slug
+  include Mongoid::Timestamps
+
   attr_accessor :current_user_compatibility_score
 
   searchkick callbacks: :async, merge_mappings: true, mappings: {

--- a/app/models/picture.rb
+++ b/app/models/picture.rb
@@ -1,6 +1,7 @@
 class Picture
   include Mongoid::Document
   include Mongoid::Paperclip
+  include Mongoid::Timestamps
 
   embedded_in :photographic, inverse_of: :pictures, polymorphic: true
 

--- a/app/models/stage.rb
+++ b/app/models/stage.rb
@@ -1,5 +1,7 @@
 class Stage
   include Mongoid::Document
+  include Mongoid::Timestamps
+
   embeds_one :time_span, cascade_callbacks: true, as: :timed
   accepts_nested_attributes_for :time_span
 

--- a/app/models/stage_action.rb
+++ b/app/models/stage_action.rb
@@ -1,5 +1,7 @@
 class StageAction
   include Mongoid::Document
+  include Mongoid::Timestamps
+
   embedded_in :stage
 
   field :name

--- a/app/models/stage_action_option.rb
+++ b/app/models/stage_action_option.rb
@@ -1,5 +1,7 @@
 class StageActionOption
   include Mongoid::Document
+  include Mongoid::Timestamps
+
   field :name, type: String
   field :description, type: String
 

--- a/app/models/stage_option.rb
+++ b/app/models/stage_option.rb
@@ -1,6 +1,7 @@
 class StageOption
   include Mongoid::Document
   include Mongoid::Slug
+  include Mongoid::Timestamps
 
   field :default_value
   field :description

--- a/app/models/time_span.rb
+++ b/app/models/time_span.rb
@@ -1,5 +1,6 @@
 class TimeSpan
   include Mongoid::Document
+  include Mongoid::Timestamps
 
   # This is a hell of a class.
 

--- a/app/models/token.rb
+++ b/app/models/token.rb
@@ -1,5 +1,6 @@
 class Token
   include Mongoid::Document
+  include Mongoid::Timestamps
 
   before_validation :generate_access_token
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,7 @@
 class User
   include Mongoid::Document
+  include Mongoid::Timestamps
+
   has_many :guides
   has_many :gardens
 

--- a/app/models/user_setting.rb
+++ b/app/models/user_setting.rb
@@ -1,6 +1,7 @@
 class UserSetting
   include Mongoid::Document
   include Mongoid::Paperclip
+  include Mongoid::Timestamps
 
   belongs_to :user
 


### PR DESCRIPTION
Every model now has :created_at and :updated_at fields. An instance's created_at and updated_at attributes are automatically filled with a UTC timestamp when the instance is created or updated. This could help with tracing database transactions for debugging purposes.