### PR TITLE
Add svg_icon as a field to `Crop` instead of a new resource

### DIFF
--- a/app/models/crop.rb
+++ b/app/models/crop.rb
@@ -17,8 +17,9 @@ class Crop
   field :guides_count, type: Fixnum, default: 0
   field :svg_icon
   validates_length_of :svg_icon,
-     minimum: 11,          # Size of empty "<svg></svg>" tag.
-     maximum: 75.kilobytes # 3x larger than largest icon.
+     minimum: 11,           # Size of empty "<svg></svg>" tag.
+     maximum: 75.kilobytes, # 3x larger than largest icon.
+     allow_blank: true
   field :description
   belongs_to :crop_data_source
   field :sun_requirements

--- a/app/models/crop.rb
+++ b/app/models/crop.rb
@@ -15,7 +15,10 @@ class Crop
 
   has_many :guides
   field :guides_count, type: Fixnum, default: 0
-
+  field :svg_icon
+  validates_length_of :svg_icon,
+     minimum: 11,          # Size of empty "<svg></svg>" tag.
+     maximum: 75.kilobytes # 3x larger than largest icon.
   field :description
   belongs_to :crop_data_source
   field :sun_requirements

--- a/app/mutations/crops/create_crop.rb
+++ b/app/mutations/crops/create_crop.rb
@@ -13,6 +13,7 @@ module Crops
         optional do
           array :common_names
           string :binomial_name
+          string :svg_icon
           string :description
           string :sun_requirements
           string :sowing_method

--- a/app/mutations/crops/update_crop.rb
+++ b/app/mutations/crops/update_crop.rb
@@ -13,6 +13,7 @@ module Crops
           array :common_names
           string :binomial_name
           string :taxon
+          string :svg_icon
           string :description
           string :sun_requirements
           string :sowing_method

--- a/app/serializers/crop_serializer.rb
+++ b/app/serializers/crop_serializer.rb
@@ -15,6 +15,7 @@ class CropSerializer < BaseSerializer
   attribute :taxon
   attribute :tags_array
   attribute :growing_degree_days
+  attribute :svg_icon
 
   has_many :pictures, serializer: PictureSerializer
 end


### PR DESCRIPTION
@simonv3 Thoughts on this one?

Originally I wanted Icon to be its own resource, but it's sounding more and more like coupling them to the Crop resource won't be a terrible idea.
