### PR TITLE
Moving rubocop to location editor linters can see.

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -7,6 +7,6 @@ java_script:
   config_file: config/.jshint.json
 ruby:
   enabled: true
-  config_file: config/.rubocup.yml
+  config: .rubocop.yml
 scss:
   config_file: config/.scss-style.yml

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,4 @@
+inherit_from: .rubocop_todo.yml
 Style/StringLiterals:
   EnforcedStyle: single_quotes
 InlineComment:


### PR DESCRIPTION
This introduces rubocop_todo.yml, which contains ignores for all the current rubocop violations.
You then chip away at this until your codebase complies again.

In the meantime, travis will fail any new rubocop fails.

.rubocop.yml should be in the root of the project, so people's editors pick it up for inline linters.
