### PR TITLE
Add margin-left: unset to logo-and-terms links

### DIFF
--- a/app/assets/stylesheets/styles/components/_footer.scss
+++ b/app/assets/stylesheets/styles/components/_footer.scss
@@ -78,6 +78,7 @@ footer {
 
     a {
       display: inline-block;
+      margin-left: unset;
     }
   }
 


### PR DESCRIPTION
Links in the footer have a `margin-left` of -0.5rem which ensures each link lines up under it's appropriate heading nicely. However, the "Terms of Service" and "Privacy" links are different in that they are not aligned in colums and are separated by an ampersand.

The spacing between the `&` the the `Privacy` link is not the same as between `Terms of Service` link and the `&`. This is because `Privacy` is pulled left by the -0.5rem. 
Removing the margin for these two links evens out the spacing.

### Before screenshot
<img width="224" alt="screen shot 2017-12-03 at 17 42 59" src="https://user-images.githubusercontent.com/647311/33528003-16617612-d852-11e7-876c-d771b5dd9010.png">

### After screenshot
<img width="228" alt="screen shot 2017-12-03 at 17 44 09" src="https://user-images.githubusercontent.com/647311/33528004-1b634050-d852-11e7-8f75-0c7f6d899094.png">

