### PR TITLE
Final changes for March 2019 release

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gem "rails"
 gem "bundler"
 
 gem "mongoid"
-gem "delayed_job_mongoid"
+gem "delayed_job_mongoid" # <= Problematic dep upgrade
 gem "delayed_job_shallow_mongoid"
 gem "kaminari-mongoid"
 gem "mongoid_taggable"

--- a/Gemfile
+++ b/Gemfile
@@ -52,7 +52,7 @@ source "https://rails-assets.org" do
   gem "rails-assets-angular-typeahead", "~> 0.3"
   gem "rails-assets-ng-tags-input", "~> 2.0"
   gem "rails-assets-ng-file-upload", "~> 12.2"
-  gem "rails-assets-moment", "~> 2.3"
+  gem "rails-assets-moment", "2.8.4"
   gem "rails-assets-showdown", "~> 0.5"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -364,7 +364,7 @@ GEM
     rails-assets-jquery (2.2.4)
     rails-assets-jquery-ui (1.12.1)
       rails-assets-jquery (>= 1.6)
-    rails-assets-moment (2.22.2)
+    rails-assets-moment (2.8.4)
     rails-assets-ng-file-upload (12.2.13)
       rails-assets-angular (> 1.2.0)
     rails-assets-ng-tags-input (2.3.0)
@@ -562,7 +562,7 @@ DEPENDENCIES
   rails-assets-angular-ui-sortable (~> 0.13)!
   rails-assets-jquery (~> 2.1)!
   rails-assets-jquery-ui (~> 1.11)!
-  rails-assets-moment (~> 2.3)!
+  rails-assets-moment (= 2.8.4)!
   rails-assets-ng-file-upload (~> 12.2)!
   rails-assets-ng-tags-input (~> 2.0)!
   rails-assets-showdown (~> 0.5)!

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -7,7 +7,7 @@ OpenFarm::Application.configure do
   config.consider_all_requests_local       = false
   config.action_controller.perform_caching = true
   config.serve_static_files = false
-  config.assets.js_compressor = :uglifier
+  config.assets.js_compressor = Uglifier.new(harmony: true)
   config.assets.compile = true
   config.assets.digest = true
   config.assets.version = '1.0'

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -10,7 +10,7 @@ OpenFarm::Application.configure do
   config.consider_all_requests_local       = false
   config.action_controller.perform_caching = true
   config.serve_static_files = false
-  config.assets.js_compressor = :uglifier
+  config.assets.js_compressor = Uglifier.new(harmony: true)
   config.assets.compile = true
   config.assets.digest = true
   config.assets.version = '1.0'


### PR DESCRIPTION
# What's New?

This PR represents the current version of OpenFarm running on production **right now**.
It is a patch update to my previous PR (#978) due to some deploy-time errors caused by a bad version upgrade of MomentJS.

# What's Next?

Although we are now on the latest version of Rails and all security updates have been applied, there is still some work to be done.

 * Vagrant setup needs to be updated (or possibly replaced with a `docker-compose` based setup).
 * Our Heroku stack is deprecated. Still needs an upgrade
 * Need to upgrade to LTS version of AngularJS (we are on 1.5, 1.7 is LTS)
 * Need to upgrade Foundation CSS library from v5 to v6. **I do very little CSS developement and this would be a great contribution for any CSS experts interested in contributing**.
 * Travis CI builds are extremely slow, most likely due to integration tests