### PR TITLE
Fix deprecation warning: include Pundit

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,7 @@
 # OUT OF DATE
 
 class ApplicationController < ActionController::Base
-  include Pundit
+  include Pundit::Authorization
   rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
   rescue_from Mongoid::Errors::DocumentNotFound, with: :record_not_found
   protect_from_forgery with: :exception


### PR DESCRIPTION
DEPRECATION WARNING: 'include Pundit' is deprecated. Please use 'include Pundit::Authorization' instead.
 (called from include at /home/runner/work/OpenFarm/OpenFarm/app/controllers/application_controller.rb:4)